### PR TITLE
6 nearest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ SRCS		:=	vec/vector1.c \
 				error/error.c \
 				scene/scene.c \
 				ray/ray.c \
-                camera/camera.c \
-                light/light.c \
-                sphere/sphere.c \
-                sphere/sphere_ray.c \
-                sphere/sphere_color.c \
+				camera/camera.c \
+				light/light.c \
+				sphere/sphere.c \
+				sphere/sphere_ray.c \
+				sphere/sphere_color.c \
 				display/init.c \
 				display/display.c \
 				display/set_each_pixel.c \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SRC_DIR		:=	srcs
 SRCS		:=	vec/vector1.c \
 				vec/vector2.c \
 				utils/utils1.c \
+				utils/utils2.c \
 				error/error.c \
 				scene/scene.c \
 				ray/ray.c \

--- a/includes/debug.h
+++ b/includes/debug.h
@@ -1,7 +1,7 @@
 #ifndef DEBUG_H
 # define DEBUG_H
 
-#include <stdio.h>
+# include <stdio.h>
 # include "vector.h"
 # include "scene.h"
 

--- a/includes/display.h
+++ b/includes/display.h
@@ -7,7 +7,9 @@
 
 # define UNREACHABLE	0
 
+typedef struct s_vector	t_vector;
 typedef struct s_scene	t_scene;
+
 typedef struct s_display
 {
 	void	*mlx_p;
@@ -30,15 +32,16 @@ typedef struct s_mlx
 }	t_mlx;
 
 /* init */
-void	init_mlxs(t_mlx *mlxs, t_display *display, t_image *image);
+void		init_mlxs(t_mlx *mlxs, t_display *display, t_image *image);
 
 /* display */
-void	my_mlx_pixel_put(\
+void		my_mlx_pixel_put(\
 					t_image *image, const int y, const int x, const int color);
-void	display(t_scene *scene);
+void		display(t_scene *scene);
 
 /* set */
-void	set_each_pixel_color(\
-					t_mlx *mlxs, const int y, const int x, t_scene *scene);
+t_vector	calc_ray_direction(const int y, const int x);
+void		set_each_pixel_color(\
+	t_mlx *mlxs, const int y, const int x, t_scene *scene);
 
 #endif

--- a/includes/display.h
+++ b/includes/display.h
@@ -8,12 +8,14 @@
 # define UNREACHABLE	0
 
 typedef struct s_scene	t_scene;
-typedef struct s_display {
+typedef struct s_display
+{
 	void	*mlx_p;
 	void	*win_p;
 }	t_display;
 
-typedef struct s_image {
+typedef struct s_image
+{
 	void	*img;
 	char	*addr;
 	int		bits_per_pixel;
@@ -21,7 +23,8 @@ typedef struct s_image {
 	int		endian;
 }	t_image;
 
-typedef struct s_mlx {
+typedef struct s_mlx
+{
 	t_display	*display;
 	t_image		*image;
 }	t_mlx;

--- a/includes/display.h
+++ b/includes/display.h
@@ -40,7 +40,6 @@ void		my_mlx_pixel_put(\
 void		display(t_scene *scene);
 
 /* set */
-t_vector	calc_ray_direction(const int y, const int x);
 void		set_each_pixel_color(\
 	t_mlx *mlxs, const int y, const int x, t_scene *scene);
 

--- a/includes/object.h
+++ b/includes/object.h
@@ -27,9 +27,6 @@ typedef struct s_discriminant
 }	t_discriminant;
 
 t_sphere		*init_sphere(char *line);
-t_vector		calc_ray_direction(const int y, const int x);
-t_discriminant	*is_intersect_to_sphere(\
-	const t_vector ray, t_camera *camera, t_sphere *sphere);
-t_intersection	*get_nearest_object(t_vector ray, t_scene *scene);
+t_intersection	get_nearest_object(t_vector ray, t_scene *scene);
 int				convert_rgb(t_rgb color);
 #endif

--- a/includes/object.h
+++ b/includes/object.h
@@ -5,8 +5,10 @@
 # include "vector.h"
 # include "color.h"
 
-typedef struct s_sphere	t_sphere;
-typedef struct s_scene	t_scene;
+typedef struct s_sphere			t_sphere;
+typedef struct s_scene			t_scene;
+typedef struct s_camera			t_camera;
+typedef struct s_intersection	t_intersection;
 
 typedef struct s_sphere
 {
@@ -24,13 +26,10 @@ typedef struct s_discriminant
 	double	d;
 }	t_discriminant;
 
-typedef struct s_point	t_point;
-typedef struct s_camera	t_camera;
-
 t_sphere		*init_sphere(char *line);
 t_vector		calc_ray_direction(const int y, const int x);
 t_discriminant	*is_intersect_to_sphere(\
 	const t_vector ray, t_camera *camera, t_sphere *sphere);
-t_point			*get_nearest_object(t_vector ray, t_scene *scene);
+t_intersection	*get_nearest_object(t_vector ray, t_scene *scene);
 int				convert_rgb(t_rgb color);
 #endif

--- a/includes/object.h
+++ b/includes/object.h
@@ -16,7 +16,21 @@ typedef struct s_sphere
 	t_sphere	*next;
 }	t_sphere;
 
-t_sphere	*init_sphere(char *line);
-bool		is_intersect_to_sphere(const int y, const int x, t_scene *scene);
+typedef struct s_discriminant
+{
+	double	a;
+	double	b;
+	double	c;
+	double	d;
+}	t_discriminant;
 
+typedef struct s_point	t_point;
+typedef struct s_camera	t_camera;
+
+t_sphere		*init_sphere(char *line);
+t_vector		calc_ray_direction(const int y, const int x);
+t_discriminant	*is_intersect_to_sphere(\
+	const t_vector ray, t_camera *camera, t_sphere *sphere);
+t_point			*get_nearest_object(t_vector ray, t_scene *scene);
+int				convert_rgb(t_rgb color);
 #endif

--- a/includes/ray.h
+++ b/includes/ray.h
@@ -12,20 +12,11 @@ typedef struct s_ray
 
 typedef struct s_intersection
 {
-	t_sphere	*sphere;//交差したsphere(要らないかも？)
-	double		distance;// 交点までの距離
-	t_vector	position;//交点の位置ベクトル
-	t_vector	normal;//交点における物体表面の法線ベクトル
-	t_vector	incident;//入射光線ベクトル
-}	t_intersection;
-
-typedef struct s_point
-{
 	t_sphere	*sphere;
-	double		distance;       /* 交点までの距離 */
-	t_vector		position;    /* 交点の位置ベクトル */
-	t_vector		normal;      /* 交点における物体表面の法線ベクトル */
-	t_vector		incident;       /* 入射光線ベクトル */
-}	t_point;
+	double		distance;
+	t_vector	position;
+	t_vector	normal;
+	t_vector	incident;
+}	t_intersection;
 
 #endif

--- a/includes/ray.h
+++ b/includes/ray.h
@@ -19,4 +19,13 @@ typedef struct s_intersection
 	t_vector	incident;//入射光線ベクトル
 }	t_intersection;
 
+typedef struct s_point
+{
+	t_sphere	*sphere;
+	double		distance;       /* 交点までの距離 */
+	t_vector		position;    /* 交点の位置ベクトル */
+	t_vector		normal;      /* 交点における物体表面の法線ベクトル */
+	t_vector		incident;       /* 入射光線ベクトル */
+}	t_point;
+
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -7,5 +7,6 @@ double		clipping(const double num, const double min, const double max);
 double		convert_deg_to_rad(double deg);
 double		convert_rad_to_deg(double rad);
 t_vector	*map_coord(t_vector *v_coord, int w, int h);
+double		positive_and_min(double a, double b);
 
 #endif

--- a/includes/vector.h
+++ b/includes/vector.h
@@ -1,7 +1,8 @@
 #ifndef VECTOR_H
 # define VECTOR_H
 
-typedef struct s_vector {
+typedef struct s_vector
+{
 	double	x;
 	double	y;
 	double	z;

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -3,10 +3,10 @@
 void	check_scene_value(t_scene *scene)
 {
 	size_t		i;
-	t_sphere	*sphere_cr;
+	t_sphere	*sphere_current;
 
 	i = 0;
-	sphere_cr = scene->list_sphere;
+	sphere_current = scene->list_sphere;
 	printf("** camera\n");
 	printf("scene->camera->pos = (%f, %f, %f)\n", scene->camera->pos.x, scene->camera->pos.y, scene->camera->pos.z);
 	printf("scene->camera->dir_n = (%f, %f, %f)\n", scene->camera->dir_n.x, scene->camera->dir_n.y, scene->camera->dir_n.z);
@@ -20,13 +20,13 @@ void	check_scene_value(t_scene *scene)
 	printf("scene->light->pos = (%f, %f, %f)\n", scene->light->pos.x, scene->light->pos.y, scene->light->pos.z);
 	printf("scene->light->bright = %f\n", scene->light->bright);
 
-	while (sphere_cr)
+	while (sphere_current)
 	{
 		printf("** list_sphere:sphere%zu\n", i);
-		printf("sphere_cr->center = (%f, %f, %f)\n", sphere_cr->center.x, sphere_cr->center.y, sphere_cr->center.z);
-		printf("sphere_cr->diameter = %f\n", sphere_cr->diameter);
-		printf("sphere_cr->color = (%hhu, %hhu, %hhu)\n", sphere_cr->color.r, sphere_cr->color.g, sphere_cr->color.b);
-		sphere_cr = sphere_cr->next;
+		printf("sphere_current->center = (%f, %f, %f)\n", sphere_current->center.x, sphere_current->center.y, sphere_current->center.z);
+		printf("sphere_current->diameter = %f\n", sphere_current->diameter);
+		printf("sphere_current->color = (%hhu, %hhu, %hhu)\n", sphere_current->color.r, sphere_current->color.g, sphere_current->color.b);
+		sphere_current = sphere_current->next;
 		i++;
 	}
 }

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -19,8 +19,8 @@ void	my_mlx_pixel_put(\
 
 static void	set_image(t_mlx *mlxs, t_scene *scene)
 {
-	size_t		y;
-	size_t		x;
+	size_t	y;
+	size_t	x;
 
 	y = 0;
 	while (y < HEIGHT)
@@ -28,9 +28,7 @@ static void	set_image(t_mlx *mlxs, t_scene *scene)
 		x = 0;
 		while (x < WIDTH)
 		{
-			//todo: set_each_pixel_colorを#5,#6,#8で実装
 			set_each_pixel_color(mlxs, y, x, scene);
-			//todo: #8 描画色取得(shadow-ray判定含む)
 			x++;
 		}
 		y++;

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -1,6 +1,8 @@
 #include <stddef.h>
 #include <stdlib.h> // exit
 #include <X11/X.h> // mlx_hook
+#include "scene.h"
+#include "vector.h"
 #include "display.h"
 #include "mlx.h"
 
@@ -17,10 +19,9 @@ void	my_mlx_pixel_put(\
 
 static void	set_image(t_mlx *mlxs, t_scene *scene)
 {
-	size_t	y;
-	size_t	x;
+	size_t		y;
+	size_t		x;
 
-	(void) scene;
 	y = 0;
 	while (y < HEIGHT)
 	{
@@ -29,7 +30,6 @@ static void	set_image(t_mlx *mlxs, t_scene *scene)
 		{
 			//todo: set_each_pixel_colorを#5,#6,#8で実装
 			set_each_pixel_color(mlxs, y, x, scene);
-			//todo: #6 nearestの情報取得(sphere)
 			//todo: #8 描画色取得(shadow-ray判定含む)
 			x++;
 		}

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -24,7 +24,10 @@ void	set_each_pixel_color(\
 	ray = vec_subtract(calc_ray_direction(y, x), scene->camera->pos);
 	nearest = get_nearest_object(ray, scene);
 	if (nearest)
+	{
+		//todo: #8 描画色取得(shadow-ray判定含む)
 		color = convert_rgb(nearest->sphere->color);
+	}
 	else
 		color = COLOR_BLUE;
 	free(nearest);

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,10 +1,11 @@
+#include <math.h>
 #include <stdlib.h>
 #include "display.h"
 #include "scene.h"
 #include "ray.h"
 
 // screen上の点の位置
-t_vector	calc_ray_direction(const int y, const int x)
+static t_vector	calc_ray_direction(const int y, const int x)
 {
 	const double	screen_x = (2.0 * x) / (WIDTH - 1) - 1.0;
 	const double	screen_y = -(2.0 * y) / (HEIGHT - 1) + 1.0;
@@ -19,17 +20,16 @@ void	set_each_pixel_color(\
 {
 	int				color;
 	t_vector		ray;
-	t_intersection	*nearest;
+	t_intersection	nearest;
 
 	ray = vec_subtract(calc_ray_direction(y, x), scene->camera->pos);
 	nearest = get_nearest_object(ray, scene);
-	if (nearest)
+	if (nearest.distance == INFINITY)
+		color = COLOR_BLUE;
+	else
 	{
 		//todo: #8 描画色取得(shadow-ray判定含む)
-		color = convert_rgb(nearest->sphere->color);
+		color = convert_rgb(nearest.sphere->color);
 	}
-	else
-		color = COLOR_BLUE;
-	free(nearest);
 	my_mlx_pixel_put(mlxs->image, y, x, color);
 }

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -16,9 +16,9 @@ t_vector	calc_ray_direction(const int y, const int x)
 void	set_each_pixel_color(\
 	t_mlx *mlxs, const int y, const int x, t_scene *scene)
 {
-	int			color;
-	t_vector	ray;
-	t_point		*nearest;
+	int				color;
+	t_vector		ray;
+	t_intersection	*nearest;
 
 	ray = vec_subtract(calc_ray_direction(y, x), scene->camera->pos);
 	nearest = get_nearest_object(ray, scene);

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "display.h"
 #include "scene.h"
 #include "ray.h"
@@ -26,5 +27,6 @@ void	set_each_pixel_color(\
 		color = convert_rgb(nearest->sphere->color);
 	else
 		color = COLOR_BLUE;
+	free(nearest);
 	my_mlx_pixel_put(mlxs->image, y, x, color);
 }

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,12 +1,29 @@
 #include "display.h"
 #include "scene.h"
+#include "ray.h"
 
-void	set_each_pixel_color(t_mlx *mlxs, const int y, const int x, t_scene *scene)
+// screen上の点の位置
+t_vector	calc_ray_direction(const int y, const int x)
 {
-	int	color;
+	const double	screen_x = (2.0 * x) / (WIDTH - 1) - 1.0;
+	const double	screen_y = -(2.0 * y) / (HEIGHT - 1) + 1.0;
+	const double	screen_z = 0.0;
+	const t_vector	ray_direction = {screen_x, screen_y, screen_z};
 
-	if (is_intersect_to_sphere(y, x, scene))
-		color = COLOR_RED;
+	return (ray_direction);
+}
+
+void	set_each_pixel_color(\
+	t_mlx *mlxs, const int y, const int x, t_scene *scene)
+{
+	int			color;
+	t_vector	ray;
+	t_point		*nearest;
+
+	ray = vec_subtract(calc_ray_direction(y, x), scene->camera->pos);
+	nearest = get_nearest_object(ray, scene);
+	if (nearest)
+		color = convert_rgb(nearest->sphere->color);
 	else
 		color = COLOR_BLUE;
 	my_mlx_pixel_put(mlxs->image, y, x, color);

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -7,4 +7,4 @@
 int	convert_rgb(t_rgb color)
 {
 	return ((color.r << 16) | (color.g << 8) | color.b);
-}
+	return ((color.r << RED_SHIFT) | (color.g << GREEN_SHIFT) | color.b);

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -2,4 +2,9 @@
 #include "vector.h"
 #include "ray.h"
 #include "object.h"
+#include "color.h"
 
+int	convert_rgb(t_rgb color)
+{
+	return ((color.r << 16) | (color.g << 8) | color.b);
+}

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -6,5 +6,5 @@
 
 int	convert_rgb(t_rgb color)
 {
-	return ((color.r << 16) | (color.g << 8) | color.b);
 	return ((color.r << RED_SHIFT) | (color.g << GREEN_SHIFT) | color.b);
+}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -42,13 +42,6 @@ static bool	is_intersect_to_sphere(const double d)
 	return (d >= 0);
 }
 
-static void	set_nearest_object(\
-	t_intersection *nearest, t_sphere *sphere, double tmp_distance)
-{
-	nearest->sphere = sphere;
-	nearest->distance = tmp_distance;
-}
-
 t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 {
 	t_intersection	nearest;
@@ -65,7 +58,10 @@ t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest.distance)
-				set_nearest_object(&nearest, sphere_cr, tmp_distance);
+			{
+				nearest.sphere = sphere_cr;
+				nearest.distance = tmp_distance;
+			}
 		}
 		sphere_cr = sphere_cr->next;
 	}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -63,26 +63,26 @@ t_intersection	*get_nearest_object(t_vector ray, t_scene *scene)
 {
 	t_intersection	*nearest;
 	t_discriminant	*discriminant;
-	t_sphere		*sphere_cr;
+	t_sphere		*sphere_current;
 	double			tmp_distance;
 
 	nearest = (t_intersection *)malloc(sizeof(t_intersection));
 	if (nearest == NULL)
 		return (NULL);
 	nearest->distance = INFINITY;
-	sphere_cr = scene->list_sphere;
-	while (sphere_cr)
+	sphere_current = scene->list_sphere;
+	while (sphere_current)
 	{
 		discriminant = \
-			is_intersect_to_sphere(ray, scene->camera, sphere_cr);
+			is_intersect_to_sphere(ray, scene->camera, sphere_current);
 		if (discriminant)
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest->distance)
-				set_nearest_object(nearest, sphere_cr, tmp_distance);
+				set_nearest_object(nearest, sphere_current, tmp_distance);
 			free(discriminant);
 		}
-		sphere_cr = sphere_cr->next;
+		sphere_current = sphere_current->next;
 	}
 	if (nearest->distance == INFINITY)
 	{

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -7,31 +7,28 @@
 #include "ray.h"
 
 // 解の方程式
-static t_discriminant	*calc_discriminant(\
-		const t_vector ray, t_camera *camera, t_sphere *sphere)
+static t_discriminant	calc_discriminant(\
+		const t_vector ray, const t_vector camera_pos, const t_sphere *sphere)
 {
-	t_discriminant	*discriminant;
-	const t_vector	v = vec_subtract(camera->pos, sphere->center);
+	t_discriminant	discriminant;
+	const t_vector	v = vec_subtract(camera_pos, sphere->center);
 
-	discriminant = (t_discriminant *)malloc(sizeof(t_discriminant));
-	if (discriminant == NULL)
-		return (NULL);
-	discriminant->a = pow(get_scalar(ray), 2);
-	discriminant->b = 2.0 * vec_dot(ray, v);
-	discriminant->c = pow(get_scalar(v), 2) - pow(sphere->diameter / 2, 2);
-	discriminant->d = pow(discriminant->b, 2) - \
-		4 * discriminant->a * discriminant->c;
+	discriminant.a = pow(get_scalar(ray), 2);
+	discriminant.b = 2.0 * vec_dot(ray, v);
+	discriminant.c = pow(get_scalar(v), 2) - pow(sphere->diameter / 2, 2);
+	discriminant.d = pow(discriminant.b, 2) - \
+		4 * discriminant.a * discriminant.c;
 	return (discriminant);
 }
 
 // rayとsphereとの距離
-static double	calc_distance_to_object(t_discriminant *discriminant)
+static double	calc_distance_to_object(t_discriminant discriminant)
 {
-	const double	num_bottom = 2.0 * discriminant->a;
-	const double	num_top1 = -1 * discriminant->b;
-	const double	num_top2 = sqrt(discriminant->d);
+	const double	num_bottom = 2.0 * discriminant.a;
+	const double	num_top1 = -1 * discriminant.b;
+	const double	num_top2 = sqrt(discriminant.d);
 
-	if (discriminant->d == 0)
+	if (discriminant.d == 0)
 		return (num_top1 / num_bottom);
 	return (positive_and_min(\
 				(num_top1 + num_top2) / num_bottom, \
@@ -39,17 +36,10 @@ static double	calc_distance_to_object(t_discriminant *discriminant)
 			));
 }
 
-// cameraからのrayとsphereとの衝突判定。衝突していればt_discriminant構造体を返す。
-t_discriminant	*is_intersect_to_sphere(\
-	const t_vector ray, t_camera *camera, t_sphere *sphere)
+// cameraからのrayとsphereとの衝突判定。衝突していればtrueを返す。
+static bool	is_intersect_to_sphere(const double d)
 {
-	t_discriminant	*discriminant;
-
-	discriminant = calc_discriminant(ray, camera, sphere);
-	if (discriminant->d >= 0)
-		return (discriminant);
-	free(discriminant);
-	return (NULL);
+	return (d >= 0);
 }
 
 static void	set_nearest_object(\
@@ -59,35 +49,25 @@ static void	set_nearest_object(\
 	nearest->distance = tmp_distance;
 }
 
-t_intersection	*get_nearest_object(t_vector ray, t_scene *scene)
+t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 {
-	t_intersection	*nearest;
-	t_discriminant	*discriminant;
+	t_intersection	nearest;
+	t_discriminant	discriminant;
 	t_sphere		*sphere_cr;
 	double			tmp_distance;
 
-	nearest = (t_intersection *)malloc(sizeof(t_intersection));
-	if (nearest == NULL)
-		return (NULL);
-	nearest->distance = INFINITY;
+	nearest.distance = INFINITY;
 	sphere_cr = scene->list_sphere;
 	while (sphere_cr)
 	{
-		discriminant = \
-			is_intersect_to_sphere(ray, scene->camera, sphere_cr);
-		if (discriminant)
+		discriminant = calc_discriminant(ray, scene->camera->pos, sphere_cr);
+		if (is_intersect_to_sphere(discriminant.d))
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
-			if (tmp_distance < nearest->distance)
-				set_nearest_object(nearest, sphere_cr, tmp_distance);
-			free(discriminant);
+			if (tmp_distance < nearest.distance)
+				set_nearest_object(&nearest, sphere_cr, tmp_distance);
 		}
 		sphere_cr = sphere_cr->next;
-	}
-	if (nearest->distance == INFINITY)
-	{
-		free(nearest);
-		return (NULL);
 	}
 	return (nearest);
 }

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -51,29 +51,34 @@ t_discriminant	*is_intersect_to_sphere(\
 	return (NULL);
 }
 
-t_point	*get_nearest_object(t_vector ray, t_scene *scene)
+static void	set_nearest_object(\
+	t_intersection *nearest, t_sphere *sphere, double tmp_distance)
 {
-	t_point			*nearest;
+	nearest->sphere = sphere;
+	nearest->distance = tmp_distance;
+}
+
+t_intersection	*get_nearest_object(t_vector ray, t_scene *scene)
+{
+	t_intersection	*nearest;
 	t_discriminant	*discriminant;
 	t_sphere		*sphere_cr;
 	double			tmp_distance;
 
-	nearest = (t_point *)malloc(sizeof(t_point));
+	nearest = (t_intersection *)malloc(sizeof(t_intersection));
 	if (nearest == NULL)
 		return (NULL);
 	nearest->distance = INFINITY;
 	sphere_cr = scene->list_sphere;
 	while (sphere_cr)
 	{
-		discriminant = is_intersect_to_sphere(ray, scene->camera, sphere_cr);
+		discriminant = \
+			is_intersect_to_sphere(ray, scene->camera, sphere_cr);
 		if (discriminant)
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest->distance)
-			{
-				nearest->sphere = sphere_cr;
-				nearest->distance = tmp_distance;
-			}
+				set_nearest_object(nearest, sphere_cr, tmp_distance);
 		}
 		sphere_cr = sphere_cr->next;
 	}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -14,12 +14,13 @@ static t_discriminant	*calc_discriminant(\
 	const t_vector	v = vec_subtract(camera->pos, sphere->center);
 
 	discriminant = (t_discriminant *)malloc(sizeof(t_discriminant));
+	if (discriminant == NULL)
+		return (NULL);
 	discriminant->a = pow(get_scalar(ray), 2);
 	discriminant->b = 2.0 * vec_dot(ray, v);
 	discriminant->c = pow(get_scalar(v), 2) - pow(sphere->diameter / 2, 2);
 	discriminant->d = pow(discriminant->b, 2) - \
 		4 * discriminant->a * discriminant->c;
-
 	return (discriminant);
 }
 
@@ -79,10 +80,14 @@ t_intersection	*get_nearest_object(t_vector ray, t_scene *scene)
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest->distance)
 				set_nearest_object(nearest, sphere_cr, tmp_distance);
+			free(discriminant);
 		}
 		sphere_cr = sphere_cr->next;
 	}
 	if (nearest->distance == INFINITY)
+	{
+		free(nearest);
 		return (NULL);
+	}
 	return (nearest);
 }

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -46,20 +46,21 @@ t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 {
 	t_intersection	nearest;
 	t_discriminant	discriminant;
-	t_sphere		*sphere_cr;
+	t_sphere		*sphere_current;
 	double			tmp_distance;
 
 	nearest.distance = INFINITY;
-	sphere_cr = scene->list_sphere;
-	while (sphere_cr)
+	sphere_current = scene->list_sphere;
+	while (sphere_current)
 	{
-		discriminant = calc_discriminant(ray, scene->camera->pos, sphere_cr);
+		discriminant = calc_discriminant(\
+							ray, scene->camera->pos, sphere_current);
 		if (is_intersect_to_sphere(discriminant.d))
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest.distance)
 			{
-				nearest.sphere = sphere_cr;
+				nearest.sphere = sphere_current;
 				nearest.distance = tmp_distance;
 			}
 		}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -39,7 +39,7 @@ static double	calc_distance_to_object(t_discriminant *discriminant)
 			));
 }
 
-// cameraからのrayとsphereとの衝突判定。衝突していれば正の距離を返す。
+// cameraからのrayとsphereとの衝突判定。衝突していればt_discriminant構造体を返す。
 t_discriminant	*is_intersect_to_sphere(\
 	const t_vector ray, t_camera *camera, t_sphere *sphere)
 {

--- a/srcs/utils/utils2.c
+++ b/srcs/utils/utils2.c
@@ -1,0 +1,9 @@
+#include <math.h>
+#include "vector.h"
+
+double	positive_and_min(double a, double b)
+{
+	if (a * b < 0)
+		return (fmax(a, b));
+	return (fmin(a, b));
+}


### PR DESCRIPTION
変数の命名、カメラからスクリーン上の座標を通過するベクトル=>rayに変更しました。（eye-vから）
衝突判定に使うベクトルで汎用的にレイと呼ばれていること、
shadow用の衝突判定でも踏襲した命名にしたかったことからですが、1wordの変数名なのも汎用的すぎて扱いづらい気もしており。
妙案あればご指摘いただけるとありがたいです。

最も手前にある物体の情報はt_intersection型(ray.hで定義)でreturnしているのですが、raytraceに使う情報もメンバに含まれます
対象のsphereのポインタと距離を格納しておいて、残りはraytraceの際に計算して使う想定です

解の方程式で使用したa,b,c,d、距離の計算にも必要だったので構造体に格納してreturnするようにしました。

よろしくお願いします！！