### PR TITLE
suggest: `get_nearest_object()`

### DIFF
--- a/includes/display.h
+++ b/includes/display.h
@@ -40,7 +40,6 @@ void		my_mlx_pixel_put(\
 void		display(t_scene *scene);
 
 /* set */
-t_vector	calc_ray_direction(const int y, const int x);
 void		set_each_pixel_color(\
 	t_mlx *mlxs, const int y, const int x, t_scene *scene);
 

--- a/includes/object.h
+++ b/includes/object.h
@@ -27,9 +27,6 @@ typedef struct s_discriminant
 }	t_discriminant;
 
 t_sphere		*init_sphere(char *line);
-t_vector		calc_ray_direction(const int y, const int x);
-t_discriminant	*is_intersect_to_sphere(\
-	const t_vector ray, t_camera *camera, t_sphere *sphere);
-t_intersection	*get_nearest_object(t_vector ray, t_scene *scene);
+t_intersection	get_nearest_object(t_vector ray, t_scene *scene);
 int				convert_rgb(t_rgb color);
 #endif

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,10 +1,11 @@
+#include <math.h>
 #include <stdlib.h>
 #include "display.h"
 #include "scene.h"
 #include "ray.h"
 
 // screen上の点の位置
-t_vector	calc_ray_direction(const int y, const int x)
+static t_vector	calc_ray_direction(const int y, const int x)
 {
 	const double	screen_x = (2.0 * x) / (WIDTH - 1) - 1.0;
 	const double	screen_y = -(2.0 * y) / (HEIGHT - 1) + 1.0;
@@ -19,17 +20,16 @@ void	set_each_pixel_color(\
 {
 	int				color;
 	t_vector		ray;
-	t_intersection	*nearest;
+	t_intersection	nearest;
 
 	ray = vec_subtract(calc_ray_direction(y, x), scene->camera->pos);
 	nearest = get_nearest_object(ray, scene);
-	if (nearest)
+	if (nearest.distance == INFINITY)
+		color = COLOR_BLUE;
+	else
 	{
 		//todo: #8 描画色取得(shadow-ray判定含む)
-		color = convert_rgb(nearest->sphere->color);
+		color = convert_rgb(nearest.sphere->color);
 	}
-	else
-		color = COLOR_BLUE;
-	free(nearest);
 	my_mlx_pixel_put(mlxs->image, y, x, color);
 }

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -6,5 +6,5 @@
 
 int	convert_rgb(t_rgb color)
 {
-	return ((color.r << 16) | (color.g << 8) | color.b);
 	return ((color.r << RED_SHIFT) | (color.g << GREEN_SHIFT) | color.b);
+}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -42,13 +42,6 @@ static bool	is_intersect_to_sphere(const double d)
 	return (d >= 0);
 }
 
-static void	set_nearest_object(\
-	t_intersection *nearest, t_sphere *sphere, double tmp_distance)
-{
-	nearest->sphere = sphere;
-	nearest->distance = tmp_distance;
-}
-
 t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 {
 	t_intersection	nearest;
@@ -65,7 +58,10 @@ t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
 			if (tmp_distance < nearest.distance)
-				set_nearest_object(&nearest, sphere_cr, tmp_distance);
+			{
+				nearest.sphere = sphere_cr;
+				nearest.distance = tmp_distance;
+			}
 		}
 		sphere_cr = sphere_cr->next;
 	}

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -7,31 +7,28 @@
 #include "ray.h"
 
 // 解の方程式
-static t_discriminant	*calc_discriminant(\
-		const t_vector ray, t_camera *camera, t_sphere *sphere)
+static t_discriminant	calc_discriminant(\
+		const t_vector ray, const t_vector camera_pos, const t_sphere *sphere)
 {
-	t_discriminant	*discriminant;
-	const t_vector	v = vec_subtract(camera->pos, sphere->center);
+	t_discriminant	discriminant;
+	const t_vector	v = vec_subtract(camera_pos, sphere->center);
 
-	discriminant = (t_discriminant *)malloc(sizeof(t_discriminant));
-	if (discriminant == NULL)
-		return (NULL);
-	discriminant->a = pow(get_scalar(ray), 2);
-	discriminant->b = 2.0 * vec_dot(ray, v);
-	discriminant->c = pow(get_scalar(v), 2) - pow(sphere->diameter / 2, 2);
-	discriminant->d = pow(discriminant->b, 2) - \
-		4 * discriminant->a * discriminant->c;
+	discriminant.a = pow(get_scalar(ray), 2);
+	discriminant.b = 2.0 * vec_dot(ray, v);
+	discriminant.c = pow(get_scalar(v), 2) - pow(sphere->diameter / 2, 2);
+	discriminant.d = pow(discriminant.b, 2) - \
+		4 * discriminant.a * discriminant.c;
 	return (discriminant);
 }
 
 // rayとsphereとの距離
-static double	calc_distance_to_object(t_discriminant *discriminant)
+static double	calc_distance_to_object(t_discriminant discriminant)
 {
-	const double	num_bottom = 2.0 * discriminant->a;
-	const double	num_top1 = -1 * discriminant->b;
-	const double	num_top2 = sqrt(discriminant->d);
+	const double	num_bottom = 2.0 * discriminant.a;
+	const double	num_top1 = -1 * discriminant.b;
+	const double	num_top2 = sqrt(discriminant.d);
 
-	if (discriminant->d == 0)
+	if (discriminant.d == 0)
 		return (num_top1 / num_bottom);
 	return (positive_and_min(\
 				(num_top1 + num_top2) / num_bottom, \
@@ -39,17 +36,10 @@ static double	calc_distance_to_object(t_discriminant *discriminant)
 			));
 }
 
-// cameraからのrayとsphereとの衝突判定。衝突していればt_discriminant構造体を返す。
-t_discriminant	*is_intersect_to_sphere(\
-	const t_vector ray, t_camera *camera, t_sphere *sphere)
+// cameraからのrayとsphereとの衝突判定。衝突していればtrueを返す。
+static bool	is_intersect_to_sphere(const double d)
 {
-	t_discriminant	*discriminant;
-
-	discriminant = calc_discriminant(ray, camera, sphere);
-	if (discriminant->d >= 0)
-		return (discriminant);
-	free(discriminant);
-	return (NULL);
+	return (d >= 0);
 }
 
 static void	set_nearest_object(\
@@ -59,35 +49,25 @@ static void	set_nearest_object(\
 	nearest->distance = tmp_distance;
 }
 
-t_intersection	*get_nearest_object(t_vector ray, t_scene *scene)
+t_intersection	get_nearest_object(t_vector ray, t_scene *scene)
 {
-	t_intersection	*nearest;
-	t_discriminant	*discriminant;
+	t_intersection	nearest;
+	t_discriminant	discriminant;
 	t_sphere		*sphere_cr;
 	double			tmp_distance;
 
-	nearest = (t_intersection *)malloc(sizeof(t_intersection));
-	if (nearest == NULL)
-		return (NULL);
-	nearest->distance = INFINITY;
+	nearest.distance = INFINITY;
 	sphere_cr = scene->list_sphere;
 	while (sphere_cr)
 	{
-		discriminant = \
-			is_intersect_to_sphere(ray, scene->camera, sphere_cr);
-		if (discriminant)
+		discriminant = calc_discriminant(ray, scene->camera->pos, sphere_cr);
+		if (is_intersect_to_sphere(discriminant.d))
 		{
 			tmp_distance = calc_distance_to_object(discriminant);
-			if (tmp_distance < nearest->distance)
-				set_nearest_object(nearest, sphere_cr, tmp_distance);
-			free(discriminant);
+			if (tmp_distance < nearest.distance)
+				set_nearest_object(&nearest, sphere_cr, tmp_distance);
 		}
 		sphere_cr = sphere_cr->next;
-	}
-	if (nearest->distance == INFINITY)
-	{
-		free(nearest);
-		return (NULL);
 	}
 	return (nearest);
 }


### PR DESCRIPTION
#6 への提案 branch を作ってみました！

例えばなのですが、
- `calc_discriminant()` は `discriminant` を計算するだけ
- `is_intersect_to_sphere()` は衝突判定するだけ
- `get_nearest_object()` は `nearest` を返すだけ
- `get_nearest_object()` の呼び出し元でその情報を元に背景 or NOT を決める

みたいな流れはどうでしょう…？👀
数値のみ、みたいな構造体が多くて変更したりもないものは特に malloc する必要がなさそうなのですが、好みですかね…？今度相談したいです！