### PR TITLE
update(mlx): destroy t_scene when close window

### DIFF
--- a/includes/display.h
+++ b/includes/display.h
@@ -29,10 +29,12 @@ typedef struct s_mlx
 {
 	t_display	*display;
 	t_image		*image;
+	t_scene		*scene;
 }	t_mlx;
 
 /* init */
-void		init_mlxs(t_mlx *mlxs, t_display *display, t_image *image);
+void		init_mlxs(\
+				t_mlx *mlxs, t_display *display, t_image *image, t_scene *scene);
 
 /* display */
 void		my_mlx_pixel_put(\

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -37,13 +37,13 @@ static void	set_image(t_mlx *mlxs, t_scene *scene)
 			mlxs->display->mlx_p, mlxs->display->win_p, mlxs->image->img, 0, 0);
 }
 
-// todo: #15 t_mlxに*sceneもたせてfree(優先度低)
 static int	close_window(const t_mlx *mlxs)
 {
 	mlx_destroy_image(mlxs->display->mlx_p, mlxs->image->img);
 	mlx_destroy_window(mlxs->display->mlx_p, mlxs->display->win_p);
 	mlx_destroy_display(mlxs->display->mlx_p);
 	free(mlxs->display->mlx_p);
+	destroy_scene(mlxs->scene);
 	exit(EXIT_SUCCESS);
 	return (UNREACHABLE);
 }
@@ -64,7 +64,7 @@ void	display(t_scene *scene)
 	t_display	display;
 	t_image		image;
 
-	init_mlxs(&mlxs, &display, &image);
+	init_mlxs(&mlxs, &display, &image, scene);
 	set_image(&mlxs, scene);
 	set_hook(&mlxs);
 	mlx_loop(mlxs.display->mlx_p);

--- a/srcs/display/init.c
+++ b/srcs/display/init.c
@@ -50,10 +50,12 @@ static void	init_image(t_mlx *mlxs)
 				&image->bits_per_pixel, &image->line_length, &image->endian);
 }
 
-void	init_mlxs(t_mlx *mlxs, t_display *display, t_image *image)
+void	init_mlxs(\
+				t_mlx *mlxs, t_display *display, t_image *image, t_scene *scene)
 {
 	mlxs->display = display;
 	mlxs->image = image;
 	init_window(mlxs);
 	init_image(mlxs);
+	mlxs->scene = scene;
 }


### PR DESCRIPTION
Issue #15 

mlx の window を閉じた時に `t_scene` も全て free する。
 
#3 parser で追加した `destroy_scene()` を使うと leak 全部なしにできるのでついでに追加しました。
(# 3 の merge が終われば直に dev への merge で ok)

no leaks です！
```shell
==285672== HEAP SUMMARY:
==285672==     in use at exit: 0 bytes in 0 blocks
==285672==   total heap usage: 301 allocs, 301 frees, 99,078 bytes allocated
==285672== 
==285672== All heap blocks were freed -- no leaks are possible
==285672== 
==285672== For lists of detected and suppressed errors, rerun with: -s
==285672== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 1)
```