### PR TITLE
t_scene のメンバcenter_screen,rotation_angleをリストラ

### DIFF
--- a/includes/scene.h
+++ b/includes/scene.h
@@ -17,14 +17,11 @@ typedef struct s_scene
 	t_light_ambient	*light_ambient;
 	t_light			*light;
 	t_deque			*list_object;
-	t_vector		center_screen;
-	double			rotation_angle;
 }	t_scene;
 
 void		init_scene(t_scene *scene);
 void		parse_lines_to_scene(t_deque *lines, t_scene *scene);
 t_vector	set_axis_base(void);
-void		set_scene_with_camera(t_scene *scene);
 void		destroy_scene(t_scene *scene);
 
 #endif

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -49,7 +49,4 @@ void	debug_print_scene_value(const t_scene *scene)
 		object_current = object_current->next;
 		i++;
 	}
-
-	printf("scene->center_screen = (%f, %f, %f)\n", scene->center_screen.x, scene->center_screen.y, scene->center_screen.z);
-	printf("scene->rotation_angle = %f)\n", convert_rad_to_deg(scene->rotation_angle));
 }

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -8,14 +8,17 @@
 static t_vector	calc_ray_direction(const int y, const int x, t_scene *scene)
 {
 	t_vector		coord_on_screen;
+	const t_vector	center_screen = get_center_screen(scene->camera);
+	const double	rotation_angle = \
+		get_angle(set_axis_base(), scene->camera->dir_n);
 
 	coord_on_screen.x = (2.0 * x) / (WIDTH - 1) - 1.0;
 	coord_on_screen.y = -(2.0 * HEIGHT / WIDTH * y) / (HEIGHT - 1) + 1.0;
 	coord_on_screen.z = 0.0;
 	coord_on_screen = \
 		rotate_vector_by_quaternion(\
-			coord_on_screen, scene->rotation_angle, scene->camera->dir_n);
-	coord_on_screen = vec_add(coord_on_screen, scene->center_screen);
+			coord_on_screen, rotation_angle, scene->camera->dir_n);
+	coord_on_screen = vec_add(coord_on_screen, center_screen);
 	return (vec_subtract(coord_on_screen, scene->camera->pos));
 }
 

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -93,6 +93,5 @@ t_scene	parse(const char *file_name)
 	// 	return (FAILURE);
 	// }
 	// todo: validation
-	set_scene_with_camera(&scene);
 	return (scene);
 }

--- a/srcs/scene/scene.c
+++ b/srcs/scene/scene.c
@@ -53,13 +53,4 @@ void	init_scene(t_scene *scene)
 	scene->light_ambient = NULL;
 	scene->light = NULL;
 	scene->list_object = deque_new();
-	scene->center_screen = (t_vector){0, 0, 0};
-	scene->rotation_angle = 0;
-}
-
-void	set_scene_with_camera(t_scene *scene)
-{
-	scene->center_screen = get_center_screen(scene->camera);
-	scene->rotation_angle = \
-		get_angle(set_axis_base(), scene->camera->dir_n);
 }


### PR DESCRIPTION
3 parserより
https://github.com/miniRT-pien42/miniRT/pull/32#discussion_r1412728480

> center_screen、rotation_angleをsceneに持たせる必要はないなと思ったので分離します🙇(https://github.com/miniRT-pien42/miniRT/issues/39)
>t_sceneにはRTファイルから読み取った情報のみを格納する方が良さそうで。

ということで、RTファイルから直接受け取った値ではない`center_screen`, `rotation_angle`を
`t_scene`から削除しました。
影響範囲的に3-parserを起点とするのが混乱なさそうなのでこのmerge先ですが、差し支えあれば教えてください！

raytraceの段階まで使う気がしてsceneに格納していたと思うのですが、
rayの計算でしか使わなさそう😇