### PR TITLE
47 fix fov

### DIFF
--- a/srcs/camera/camera.c
+++ b/srcs/camera/camera.c
@@ -16,12 +16,13 @@ t_camera	*init_camera(const char **line)
 }
 
 //カメラのorientation vectorの延長線上にあり、WIDTHが2の画角を取れる平面の中心座標
+// (WIDTH=2のとき画角のWIDTHが円錐に外接する)
 t_vector	get_center_screen(t_camera *camera)
 {
 	double	diameter;
 	double	t;
 
-	diameter = sqrt(pow(WIDTH * 2 / WIDTH, 2) + pow(HEIGHT * 2 / WIDTH, 2));
+	diameter = 2.0;
 	t = (diameter / 2) / tan(convert_deg_to_rad(camera->fov / 2.0));
 	return (vec_add(camera->pos, vec_scalar(camera->dir_n, t)));
 


### PR DESCRIPTION
間違えました！
カメラの画角をFOVで指定された角度の円錐ととって、断面をスクリーンとする。
スクリーンサイズのWIDTHが2となるところに断面を取りたい。
ので、シンプルに直径2になるところで断面をとって
WIDTH方向が外接するようにすればよいだけでした。