### PR TITLE
Fix header

### DIFF
--- a/includes/camera.h
+++ b/includes/camera.h
@@ -1,7 +1,6 @@
 #ifndef CAMERA_H
 # define CAMERA_H
 
-# include "vector.h"
 # include "display.h"
 # include "helpers.h"
 

--- a/includes/debug.h
+++ b/includes/debug.h
@@ -1,8 +1,8 @@
 #ifndef DEBUG_H
 # define DEBUG_H
 
+# include "object.h"
 # include "scene.h"
-# include "ft_deque.h"
 
 void	debug_print_scene_value(const t_scene *scene);
 void	print_2d_array(char **strs);

--- a/includes/helpers.h
+++ b/includes/helpers.h
@@ -1,7 +1,7 @@
 #ifndef HELPERS_H
 # define HELPERS_H
 
-# define EPSILON 1e-6
+# define EPSILON (1e-6)
 
 # include "vector.h"
 

--- a/includes/light.h
+++ b/includes/light.h
@@ -1,8 +1,8 @@
 #ifndef LIGHT_H
 # define LIGHT_H
 
-# include "vector.h"
 # include "color.h"
+# include "vector.h"
 
 typedef struct s_light_ambient
 {

--- a/includes/object.h
+++ b/includes/object.h
@@ -1,9 +1,9 @@
 #ifndef OBJECT_H
 # define OBJECT_H
 
-# include "vector.h"
 # include "color.h"
 # include "ft_deque.h"
+# include "vector.h"
 
 typedef struct s_sphere			t_sphere;
 typedef struct s_scene			t_scene;

--- a/includes/ray.h
+++ b/includes/ray.h
@@ -1,7 +1,7 @@
 #ifndef RAY_H
 # define RAY_H
 
-# include "object.h"
+# include "vector.h"
 
 # define NO_INTERSECTION	(-1)
 

--- a/includes/scene.h
+++ b/includes/scene.h
@@ -7,7 +7,6 @@
 
 # include "camera.h"
 # include "light.h"
-# include "object.h"
 
 typedef struct s_deque	t_deque;
 

--- a/srcs/cylinder/cylinder_ray.c
+++ b/srcs/cylinder/cylinder_ray.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include "ray.h"
 #include "scene.h"
+#include "object.h"
 
 static double	calc_a_for_cylinder(t_ray *ray, t_cylinder *cylinder)
 {

--- a/srcs/cylinder/cylinder_ray.c
+++ b/srcs/cylinder/cylinder_ray.c
@@ -1,7 +1,7 @@
-#include <math.h>
+#include "object.h"
 #include "ray.h"
 #include "scene.h"
-#include "object.h"
+#include <math.h>
 
 static double	calc_a_for_cylinder(t_ray *ray, t_cylinder *cylinder)
 {

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -1,7 +1,4 @@
 #include "debug.h"
-#include "object.h"
-#include "scene.h"
-#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -1,9 +1,9 @@
+#include "debug.h"
+#include "object.h"
+#include "scene.h"
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "debug.h"
-#include "scene.h"
-#include "object.h"
 
 void	debug_print_vector(const char *name, const t_vector vec)
 {

--- a/srcs/debug/print_object.c
+++ b/srcs/debug/print_object.c
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include "debug.h"
 #include "object.h"
+#include <stdio.h>
 
 void	debug_print_sphere(t_sphere *sphere)
 {

--- a/srcs/debug/print_object.c
+++ b/srcs/debug/print_object.c
@@ -1,5 +1,4 @@
 #include "debug.h"
-#include "object.h"
 #include <stdio.h>
 
 void	debug_print_sphere(t_sphere *sphere)

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -1,10 +1,10 @@
+#include "display.h"
+#include "mlx.h"
+#include "scene.h"
+#include "vector.h"
 #include <stddef.h>
 #include <stdlib.h> // exit
 #include <X11/X.h> // mlx_hook
-#include "scene.h"
-#include "vector.h"
-#include "display.h"
-#include "mlx.h"
 
 void	my_mlx_pixel_put(\
 					t_image *image, const int y, const int x, const int color)

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -1,8 +1,5 @@
-#include "display.h"
 #include "mlx.h"
 #include "scene.h"
-#include "vector.h"
-#include <stddef.h>
 #include <stdlib.h> // exit
 #include <X11/X.h> // mlx_hook
 

--- a/srcs/display/init.c
+++ b/srcs/display/init.c
@@ -1,7 +1,7 @@
-#include <stdlib.h> // free
 #include "display.h"
-#include "mlx.h"
 #include "error.h"
+#include "mlx.h"
+#include <stdlib.h> // free
 
 static void	*init_mlx_p(void)
 {

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,9 +1,5 @@
-#include "display.h"
 #include "object.h"
-#include "ray.h"
 #include "scene.h"
-#include <math.h>
-#include <stdlib.h>
 
 // screen上の点の位置
 static t_vector	calc_ray_direction(const int y, const int x, t_scene *scene)

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,3 +1,4 @@
+#include "object.h"
 #include <math.h>
 #include <stdlib.h>
 #include "display.h"

--- a/srcs/display/set_each_pixel.c
+++ b/srcs/display/set_each_pixel.c
@@ -1,9 +1,9 @@
+#include "display.h"
 #include "object.h"
+#include "ray.h"
+#include "scene.h"
 #include <math.h>
 #include <stdlib.h>
-#include "display.h"
-#include "scene.h"
-#include "ray.h"
 
 // screen上の点の位置
 static t_vector	calc_ray_direction(const int y, const int x, t_scene *scene)

--- a/srcs/helpers/helpers_math1.c
+++ b/srcs/helpers/helpers_math1.c
@@ -1,5 +1,5 @@
-#include <math.h>
 #include "vector.h"
+#include <math.h>
 
 double	clipping(const double num, const double min, const double max)
 {

--- a/srcs/light/light.c
+++ b/srcs/light/light.c
@@ -1,5 +1,5 @@
-#include "light.h"
 #include "libft.h"
+#include "light.h"
 #include "parse.h"
 #include <stdlib.h> // todo: rm (atof)
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,12 +1,10 @@
+#include "debug.h"
+#include "display.h"
+#include "parse.h"
+#include "scene.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "scene.h"
-// #include "ray.h"
-// #include "vector.h"
-#include "display.h"
-#include "debug.h"
-#include "parse.h"
 
 static bool	is_valid_argc(const int argc)
 {

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,8 +1,5 @@
 #include "debug.h"
-#include "display.h"
 #include "parse.h"
-#include "scene.h"
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/srcs/object/distance.c
+++ b/srcs/object/distance.c
@@ -1,6 +1,6 @@
-#include <math.h>
 #include "ray.h"
 #include "scene.h"
+#include <math.h>
 
 // 共通して使えそう
 void	calc_distance_by_discriminant(\

--- a/srcs/object/distance.c
+++ b/srcs/object/distance.c
@@ -1,5 +1,3 @@
-#include "ray.h"
-#include "scene.h"
 #include <math.h>
 
 // 共通して使えそう

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -1,7 +1,7 @@
-#include <math.h>
-#include "scene.h"
-#include "ray.h"
 #include "object.h"
+#include "ray.h"
+#include "scene.h"
+#include <math.h>
 
 t_shape	get_object_type(void *object)
 {

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -1,5 +1,4 @@
 #include "object.h"
-#include "ray.h"
 #include "scene.h"
 #include <math.h>
 

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include "scene.h"
 #include "ray.h"
+#include "object.h"
 
 t_shape	get_object_type(void *object)
 {

--- a/srcs/parser/convert.c
+++ b/srcs/parser/convert.c
@@ -1,6 +1,6 @@
+#include "color.h"
 #include "libft.h"
 #include "vector.h"
-#include "color.h"
 #include <stdlib.h> // todo: rm (atof)
 
 t_vector	convert_line_to_vector(const char *line, const char delimiter)

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -1,12 +1,7 @@
 #include "debug.h"
-#include "ft_deque.h"
 #include "get_next_line.h"
 #include "libft.h"
-#include "result.h"
-#include "scene.h"
 #include <fcntl.h> // open
-#include <stdio.h>
-#include <stdlib.h>
 
 /*
 A   ratio      r,g,b

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -1,12 +1,12 @@
+#include "debug.h"
+#include "ft_deque.h"
+#include "get_next_line.h"
+#include "libft.h"
+#include "result.h"
+#include "scene.h"
 #include <fcntl.h> // open
 #include <stdio.h>
 #include <stdlib.h>
-#include "scene.h"
-#include "libft.h"
-#include "ft_deque.h"
-#include "get_next_line.h"
-#include "result.h"
-#include "debug.h"
 
 /*
 A   ratio      r,g,b

--- a/srcs/plane/plane.c
+++ b/srcs/plane/plane.c
@@ -1,7 +1,6 @@
 #include "libft.h"
 #include "object.h"
 #include "parse.h"
-#include <stdlib.h> // todo: rm (atof)
 
 t_plane	*init_plane(const char **line)
 {

--- a/srcs/plane/plane_ray.c
+++ b/srcs/plane/plane_ray.c
@@ -1,11 +1,6 @@
-#include "display.h"
-#include "helpers.h"
 #include "object.h"
-#include "ray.h"
 #include "scene.h"
-#include "vector.h"
 #include <math.h>
-#include <stdlib.h>
 
 double	get_distance_to_plane(t_vector ray, t_scene *scene, t_plane *plane)
 {

--- a/srcs/plane/plane_ray.c
+++ b/srcs/plane/plane_ray.c
@@ -1,11 +1,11 @@
-#include <stdlib.h>
-#include <math.h>
-#include "vector.h"
 #include "display.h"
-#include "scene.h"
 #include "helpers.h"
 #include "object.h"
 #include "ray.h"
+#include "scene.h"
+#include "vector.h"
+#include <math.h>
+#include <stdlib.h>
 
 double	get_distance_to_plane(t_vector ray, t_scene *scene, t_plane *plane)
 {

--- a/srcs/plane/plane_ray.c
+++ b/srcs/plane/plane_ray.c
@@ -4,6 +4,7 @@
 #include "display.h"
 #include "scene.h"
 #include "helpers.h"
+#include "object.h"
 #include "ray.h"
 
 double	get_distance_to_plane(t_vector ray, t_scene *scene, t_plane *plane)

--- a/srcs/ray/ray.c
+++ b/srcs/ray/ray.c
@@ -1,3 +1,3 @@
-#include <stdlib.h>
 #include "object.h"
+#include <stdlib.h>
 

--- a/srcs/ray/ray.c
+++ b/srcs/ray/ray.c
@@ -1,3 +1,0 @@
-#include "object.h"
-#include <stdlib.h>
-

--- a/srcs/scene/destroy.c
+++ b/srcs/scene/destroy.c
@@ -1,4 +1,3 @@
-#include "ft_deque.h"
 #include "libft.h"
 #include "object.h"
 #include "scene.h"

--- a/srcs/scene/destroy.c
+++ b/srcs/scene/destroy.c
@@ -1,7 +1,7 @@
-#include "scene.h"
-#include "libft.h"
 #include "ft_deque.h"
+#include "libft.h"
 #include "object.h"
+#include "scene.h"
 
 static void	del_object(void *args)
 {

--- a/srcs/scene/scene.c
+++ b/srcs/scene/scene.c
@@ -1,7 +1,5 @@
-#include "ft_deque.h"
 #include "libft.h"
 #include "object.h"
-#include "parse.h"
 #include "scene.h"
 
 t_vector	set_axis_base(void)

--- a/srcs/scene/scene.c
+++ b/srcs/scene/scene.c
@@ -1,8 +1,8 @@
 #include "ft_deque.h"
 #include "libft.h"
-#include "scene.h"
+#include "object.h"
 #include "parse.h"
-#include "ft_deque.h"
+#include "scene.h"
 
 t_vector	set_axis_base(void)
 {

--- a/srcs/sphere/sphere.c
+++ b/srcs/sphere/sphere.c
@@ -1,5 +1,5 @@
-#include "object.h"
 #include "libft.h"
+#include "object.h"
 #include "parse.h"
 #include <stdlib.h> // todo: rm (atof)
 

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -1,8 +1,8 @@
-#include <math.h>
-#include "vector.h"
-#include "ray.h"
-#include "object.h"
 #include "color.h"
+#include "object.h"
+#include "ray.h"
+#include "vector.h"
+#include <math.h>
 
 int	convert_rgb(t_rgb color)
 {

--- a/srcs/sphere/sphere_color.c
+++ b/srcs/sphere/sphere_color.c
@@ -1,8 +1,4 @@
-#include "color.h"
 #include "object.h"
-#include "ray.h"
-#include "vector.h"
-#include <math.h>
 
 int	convert_rgb(t_rgb color)
 {

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -1,11 +1,6 @@
-#include "display.h"
-#include "helpers.h"
 #include "object.h"
-#include "ray.h"
 #include "scene.h"
-#include "vector.h"
 #include <math.h>
-#include <stdlib.h>
 
 static double	calc_a_for_sphere(t_vector ray)
 {

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -1,11 +1,11 @@
-#include <stdlib.h>
-#include <math.h>
-#include "vector.h"
 #include "display.h"
-#include "scene.h"
 #include "helpers.h"
 #include "object.h"
 #include "ray.h"
+#include "scene.h"
+#include "vector.h"
+#include <math.h>
+#include <stdlib.h>
 
 static double	calc_a_for_sphere(t_vector ray)
 {

--- a/srcs/sphere/sphere_ray.c
+++ b/srcs/sphere/sphere_ray.c
@@ -4,6 +4,7 @@
 #include "display.h"
 #include "scene.h"
 #include "helpers.h"
+#include "object.h"
 #include "ray.h"
 
 static double	calc_a_for_sphere(t_vector ray)

--- a/srcs/vec/quaternion.c
+++ b/srcs/vec/quaternion.c
@@ -1,5 +1,4 @@
 #include "scene.h"
-#include "vector.h"
 #include <math.h>
 
 //回転クォータニオン axisは基準となるz軸

--- a/srcs/vec/quaternion.c
+++ b/srcs/vec/quaternion.c
@@ -1,6 +1,6 @@
-#include <math.h>
-#include "vector.h"
 #include "scene.h"
+#include "vector.h"
+#include <math.h>
 
 //回転クォータニオン axisは基準となるz軸
 static t_quaternion	get_rotate_quaternion(t_vector axis, double angle)

--- a/srcs/vec/vector1.c
+++ b/srcs/vec/vector1.c
@@ -1,5 +1,5 @@
-#include <math.h>
 #include "vector.h"
+#include <math.h>
 
 t_vector	vec_add(const t_vector a, const t_vector b)
 {

--- a/srcs/vec/vector2.c
+++ b/srcs/vec/vector2.c
@@ -1,5 +1,5 @@
-#include <math.h>
 #include "vector.h"
+#include <math.h>
 
 t_vector	vec_scalar(const t_vector v, double scalar)
 {

--- a/srcs/vec/vector3.c
+++ b/srcs/vec/vector3.c
@@ -1,5 +1,4 @@
 #include "helpers.h"
-#include "vector.h"
 #include <math.h>
 
 //2つの正規化ベクトルが並行で逆方向か判定

--- a/srcs/vec/vector3.c
+++ b/srcs/vec/vector3.c
@@ -1,6 +1,6 @@
-#include <math.h>
-#include "vector.h"
 #include "helpers.h"
+#include "vector.h"
+#include <math.h>
 
 //2つの正規化ベクトルが並行で逆方向か判定
 bool	is_vector_opposite(t_vector a, t_vector b)


### PR DESCRIPTION
すみません、ちょっとそれた PR を生やしてしまいました…

- `object.h` の依存関係の軽い修正
- header が多い時に二重で include を書きそうになったので alphabet 順に sort
　→ 標準ライブラリと自作ライブラリの順番を変更しました。本で読んだのですが、先に標準ライブラリを include するとそれに依存した自作ライブラリでたまたま動いている可能性があるかもしれないから、だそうで納得したからです。(今回は関係ないとは思いますが…)
- 使ってない header include を削除
- ついでに数字と文字が混ざった define は念のため `( )` をつけた

多分 header いじるとすごい conflict すると思うのですが、今の内に少しきれいにと思いまして…
完成してから最後に一気に変更、でも全然大丈夫ではあります…