### PR TITLE
35 parse validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SRCS		:=	cylinder/cylinder_ray.c \
 				debug/debug.c \
 				debug/print_object.c \
 				debug/print_rt_file.c \
+				parser/check_file_path.c \
 				parser/convert.c \
 				parser/parse.c \
 				main.c

--- a/includes/error.h
+++ b/includes/error.h
@@ -1,8 +1,10 @@
 #ifndef ERROR_H
 # define ERROR_H
 
-# define ERR_MLX	"Error: mlx"
-# define ERR_ARGS	"Error: Invalid arguments"
+# define ERR_MLX		"Error: mlx"
+# define ERR_ARGS		"Error: Invalid arguments"
+# define ERR_FILEPATH	"Error: Invalid filepath"
+# define ERR_RTFILE		"Error: Invalid .rt file"
 
 void	error_exit(const char *message);
 

--- a/includes/error.h
+++ b/includes/error.h
@@ -2,6 +2,7 @@
 # define ERROR_H
 
 # define ERR_MLX	"Error: mlx"
+# define ERR_ARGS	"Error: Invalid arguments"
 
 void	error_exit(const char *message);
 

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -1,6 +1,12 @@
 #ifndef PARSE_H
 # define PARSE_H
 
+# include <stdbool.h>
+# include <vector.h>
+
+# define OPEN_ERROR		(-1)
+# define FILE_EXTENSION	".rt"
+
 typedef struct s_scene	t_scene;
 typedef struct s_rgb	t_rgb;
 
@@ -10,5 +16,8 @@ t_scene		parse(const char *file_name);
 /* convert */
 t_vector	convert_line_to_vector(const char *line, const char delimiter);
 t_rgb		convert_line_to_rgb(const char *line, const char delimiter);
+
+/* validation */
+bool		is_valid_file_path(const char *filepath);
 
 #endif

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -4,6 +4,7 @@ SRC_DIR		:=	srcs
 SRCS		:=	ft_free.c \
 				ft_memcpy.c \
 				ft_memmove.c \
+				ft_putstr_fd.c \
 				ft_split.c \
 				ft_strchr.c \
 				ft_strcmp.c \

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -4,6 +4,7 @@ SRC_DIR		:=	srcs
 SRCS		:=	ft_free.c \
 				ft_memcpy.c \
 				ft_memmove.c \
+				ft_min.c \
 				ft_putstr_fd.c \
 				ft_split.c \
 				ft_strchr.c \
@@ -14,8 +15,10 @@ SRCS		:=	ft_free.c \
 				ft_strlcpy_void.c \
 				ft_strlcpy.c \
 				ft_strlen.c \
+				ft_strncmp.c \
 				ft_strndup.c \
 				ft_strnlen.c \
+				ft_strnstr.c \
 				get_next_line.c \
 				x_malloc.c
 

--- a/libft/includes/libft.h
+++ b/libft/includes/libft.h
@@ -8,6 +8,7 @@ void	*ft_free(void **ptr);
 void	*free_2d_array(char ***ptr);
 void	*ft_memcpy(void *dst, const void *src, size_t n);
 void	*ft_memmove(void *dst, const void *src, size_t len);
+void	ft_putstr_fd(const char *s, int fd);
 char	**ft_split(char const *s, char c);
 char	*ft_strchr(char *s, int int_c);
 bool	ft_strchr_bool(const char *s, int int_c);

--- a/libft/includes/libft.h
+++ b/libft/includes/libft.h
@@ -8,6 +8,7 @@ void	*ft_free(void **ptr);
 void	*free_2d_array(char ***ptr);
 void	*ft_memcpy(void *dst, const void *src, size_t n);
 void	*ft_memmove(void *dst, const void *src, size_t len);
+size_t	ft_min(const size_t x, const size_t y);
 void	ft_putstr_fd(const char *s, int fd);
 char	**ft_split(char const *s, char c);
 char	*ft_strchr(char *s, int int_c);
@@ -19,8 +20,10 @@ char	*ft_strjoin(char const *s1, char const *s2);
 void	ft_strlcpy_void(char *dst, const char *src, size_t dstsize);
 size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize);
 size_t	ft_strlen(const char *s);
+int 	ft_strncmp(const char *s1, const char *s2, size_t n);
 char	*ft_strndup(const char *s, const size_t maxlen);
 size_t	ft_strnlen(const char *s, const size_t maxlen);
+char	*ft_strnstr(const char *haystack, const char *needle, size_t len);
 
 void	*x_malloc(const size_t size);
 

--- a/libft/srcs/ft_min.c
+++ b/libft/srcs/ft_min.c
@@ -1,0 +1,8 @@
+#include "libft.h"
+
+size_t	ft_min(const size_t x, const size_t y)
+{
+	if (x <= y)
+		return (x);
+	return (y);
+}

--- a/libft/srcs/ft_putstr_fd.c
+++ b/libft/srcs/ft_putstr_fd.c
@@ -1,0 +1,9 @@
+#include "libft.h"
+#include <unistd.h>
+
+void	ft_putstr_fd(const char *s, int fd)
+{
+	if (s == NULL)
+		return ;
+	write(fd, s, ft_strlen(s));
+}

--- a/libft/srcs/ft_strncmp.c
+++ b/libft/srcs/ft_strncmp.c
@@ -1,0 +1,13 @@
+#include "libft.h"
+
+int	ft_strncmp(const char *s1, const char *s2, size_t n)
+{
+	size_t	i;
+
+	if (n == 0)
+		return (0);
+	i = 0;
+	while ((i + 1 < n) && s1[i] && (s1[i] == s2[i]))
+		i++;
+	return ((unsigned char)s1[i] - (unsigned char)s2[i]);
+}

--- a/libft/srcs/ft_strnstr.c
+++ b/libft/srcs/ft_strnstr.c
@@ -1,0 +1,22 @@
+#include "libft.h"
+
+char	*ft_strnstr(const char *haystack, const char *needle, size_t len)
+{
+	size_t	len_needle;
+	size_t	i;
+
+	len_needle = ft_strlen(needle);
+	if (!len_needle)
+		return ((char *)haystack);
+	if (haystack == NULL && len == 0)
+		return (NULL);
+	len = ft_min(len, ft_strlen(haystack));
+	i = 0;
+	while (i + len_needle <= len)
+	{
+		if (ft_strncmp(&haystack[i], needle, len_needle) == 0)
+			return ((char *)&haystack[i]);
+		i++;
+	}
+	return (NULL);
+}

--- a/srcs/error/error.c
+++ b/srcs/error/error.c
@@ -1,9 +1,12 @@
+#include "libft.h"
 #include <stdio.h>
 #include <stdlib.h> // exit
+#include <unistd.h>
 
 // todo: #12 perror
 void	error_exit(const char *message)
 {
-	printf("%s\n", message);
+	ft_putstr_fd(message, STDERR_FILENO);
+	ft_putstr_fd("\n", STDERR_FILENO);
 	exit(EXIT_FAILURE);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -35,10 +35,7 @@ int	main(int argc, char **argv)
 	if (!is_valid_argc(argc))
 		error_exit(ERR_ARGS);
 	if (!is_valid_file_path(argv[1]))
-	{
-		// todo: put error
-		return (EXIT_FAILURE);
-	}
+		error_exit(ERR_FILEPATH);
 	scene = parse(argv[1]);
 	if (!is_valid_scene_value(&scene))
 	{

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -14,13 +14,6 @@ static bool	is_valid_argc(const int argc)
 	return (argc == 2);
 }
 
-// todo: validate .rt file
-static bool	is_valid_file_path(const char *filepath)
-{
-	printf("filepath: %s\n", filepath);
-	return (true);
-}
-
 // todo: validate scene value
 static bool	is_valid_scene_value(const t_scene *scene)
 {

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -7,6 +7,7 @@
 #include "display.h"
 #include "debug.h"
 #include "parse.h"
+#include "error.h"
 
 static bool	is_valid_argc(const int argc)
 {
@@ -32,10 +33,7 @@ int	main(int argc, char **argv)
 	t_scene	scene;
 
 	if (!is_valid_argc(argc))
-	{
-		// todo: put error
-		return (EXIT_FAILURE);
-	}
+		error_exit(ERR_ARGS);
 	if (!is_valid_file_path(argv[1]))
 	{
 		// todo: put error

--- a/srcs/parser/check_file_path.c
+++ b/srcs/parser/check_file_path.c
@@ -1,0 +1,58 @@
+#include "libft.h"
+#include "parse.h"
+#include <fcntl.h> // open
+#include <stdio.h>
+#include <unistd.h>
+
+static char	*find_head_extention_pointer(\
+								const char *filepath, const size_t len_filepath)
+{
+	return (ft_strnstr(filepath, FILE_EXTENSION, len_filepath));
+}
+
+static bool	ends_with_single_extension(\
+						const char *extension_ptr, const size_t len_filepath)
+{
+	return (ft_strncmp(extension_ptr, FILE_EXTENSION, len_filepath) == 0);
+}
+
+// check hidden file or not. (.rt, /.rt)
+static bool	is_valid_filetype(const char *filepath, const char *extension_ptr)
+{
+	if (filepath == extension_ptr)
+		return (false);
+	if (*(extension_ptr - 1) == '/')
+		return (false);
+	return (true);
+}
+
+static bool	is_file_exist(const char *filepath)
+{
+	int	fd;
+
+	fd = open(filepath, O_RDONLY);
+	if (fd == OPEN_ERROR)
+	{
+		perror("open");
+		return (false);
+	}
+	close(fd);
+	return (true);
+}
+
+bool	is_valid_file_path(const char *filepath)
+{
+	const size_t	len_filepath = ft_strlen(filepath);
+	const char		*extension_ptr = \
+							find_head_extention_pointer(filepath, len_filepath);
+
+	if (extension_ptr == NULL)
+		return (false);
+	if (!ends_with_single_extension(extension_ptr, len_filepath))
+		return (false);
+	if (!is_valid_filetype(filepath, extension_ptr))
+		return (false);
+	if (!is_file_exist(filepath))
+		return (false);
+	return (true);
+}


### PR DESCRIPTION
Issue #35 

一旦 filepath 自体が正しいか、と `.rt` が含まれているなら存在するファイルなのか check する、ところまで追加です。
まだ実際に `.rt` file の中身の check はしていません。(→ PR #55 )
漏れなさそうかご確認お願いします🙏

- [x] Error 出力は stderr へ
- [x] `is_valid_argc()`
- [x] `is_valid_filepath()`
  - `.rt` が filepath に
    - 1 つだけ含まれる
    - 末尾である
    - 隠しファイルではない (`.rt` の前に `/` 以外の文字列がある)
  - (`.rt` file として正しいなら) 存在する file である


```shell
# OK
./miniRT exist.rt
./miniRT rt_files/exist.rt

# NG
./miniRT .notrt
./miniRT .rt.rt
./miniRT exist.rt.rt
./miniRT .rttttt
./miniRT .rt
./miniRT /.rt
./miniRT not_exist.rt
```