### PR TITLE
parse: 残 todo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ SRCS		:=	cylinder/cylinder_color.c \
 				quaternion/quaternion.c \
 				color/color.c \
 				helpers/helpers_math1.c \
+				helpers/x_ft_split.c \
+				helpers/x_get_next_line.c \
+				helpers/x_malloc.c \
+				helpers/x_open.c \
 				error/error.c \
 				scene/scene.c \
 				ray/ray.c \

--- a/includes/error.h
+++ b/includes/error.h
@@ -1,12 +1,14 @@
 #ifndef ERROR_H
 # define ERROR_H
 
-# define ERR_MLX		"Error: mlx"
-# define ERR_ARGS		"Error: Invalid arguments"
-# define ERR_FILEPATH	"Error: Invalid filepath"
-# define ERR_RTFILE		"Error: Invalid .rt value"
+# define ERR_MESSAGE	"Error"
+# define ERR_MLX		"mlx"
+# define ERR_ARGS		"Invalid arguments"
+# define ERR_FILEPATH	"Invalid filepath"
+# define ERR_RTFILE		"Invalid .rt value"
 
 /* error */
+void	putstr_with_endl(const char *message);
 void	error_exit(const char *message);
 
 #endif

--- a/includes/helpers.h
+++ b/includes/helpers.h
@@ -15,9 +15,9 @@ double		convert_rad_to_deg(double rad);
 t_vector	*convert_coord(t_vector *v_coord, int w, int h);
 
 /* wrapper */
-char    	**x_ft_split(char const *str, const char *charset);
-char	    *x_get_next_line(int fd);
-void	    *x_malloc(const size_t size);
-int		    x_open(const char *path, int open_flag);
+char		**x_ft_split(char const *str, const char *charset);
+char		*x_get_next_line(int fd);
+void		*x_malloc(const size_t size);
+int			x_open(const char *path, int open_flag);
 
 #endif

--- a/includes/helpers.h
+++ b/includes/helpers.h
@@ -1,7 +1,10 @@
 #ifndef HELPERS_H
 # define HELPERS_H
 
+# include <stddef.h>
+
 # define EPSILON (1e-6)
+# define OPEN_ERROR (-1)
 
 typedef struct s_vector	t_vector;
 
@@ -10,5 +13,11 @@ double		clipping(const double num, const double min, const double max);
 double		convert_deg_to_rad(double deg);
 double		convert_rad_to_deg(double rad);
 t_vector	*convert_coord(t_vector *v_coord, int w, int h);
+
+/* wrapper */
+char    	**x_ft_split(char const *str, const char *charset);
+char	    *x_get_next_line(int fd);
+void	    *x_malloc(const size_t size);
+int		    x_open(const char *path, int open_flag);
 
 #endif

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -4,7 +4,6 @@
 # include <stdbool.h>
 # include <stdint.h>
 
-# define OPEN_ERROR				(-1)
 # define FILE_EXTENSION			".rt"
 # define AT_LEAST_LINES			3
 # define DELIMITER_WHITE_SPACE	" \f\n\r\t\v"

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -23,8 +23,7 @@ SRCS		:=	ft_atoi.c \
 				ft_strnlen.c \
 				ft_strnstr.c \
 				ft_strtod.c \
-				get_next_line.c \
-				x_malloc.c
+				get_next_line.c
 
 #--------------------------------------------
 # ft_deque

--- a/libft/includes/get_next_line.h
+++ b/libft/includes/get_next_line.h
@@ -2,7 +2,7 @@
 # define GET_NEXT_LINE_H
 
 # include <stddef.h>
-# include "../../includes/result.h"
+# include <stdbool.h>
 
 # define READ_ERROR	(-1)
 # define LF			'\n'
@@ -12,6 +12,6 @@
 #  define BUFFER_SIZE	1024
 # endif
 
-char	*get_next_line(int fd, t_result *result);
+char	*get_next_line(int fd, bool *is_error);
 
 #endif

--- a/libft/includes/libft.h
+++ b/libft/includes/libft.h
@@ -29,6 +29,4 @@ size_t	ft_strnlen(const char *s, const size_t maxlen);
 char	*ft_strnstr(const char *haystack, const char *needle, size_t len);
 double	ft_strtod(const char *s, const char **endptr);
 
-void	*x_malloc(const size_t size);
-
 #endif

--- a/libft/srcs/ft_deque/dq_new.c
+++ b/libft/srcs/ft_deque/dq_new.c
@@ -1,11 +1,13 @@
 #include "ft_deque.h"
-#include "libft.h"
+#include <stdlib.h>
 
 t_deque	*deque_new(void)
 {
 	t_deque	*deque;
 
-	deque = (t_deque *)x_malloc(sizeof(t_deque));
+	deque = (t_deque *)malloc(sizeof(t_deque));
+	if (deque == NULL)
+		return (NULL);
 	deque->node = NULL;
 	deque->size = 0;
 	return (deque);

--- a/libft/srcs/ft_deque/dq_node_new.c
+++ b/libft/srcs/ft_deque/dq_node_new.c
@@ -1,11 +1,13 @@
 #include "ft_deque.h"
-#include "libft.h"
+#include <stdlib.h>
 
 t_deque_node	*deque_node_new(void *content)
 {
 	t_deque_node	*node;
 
-	node = (t_deque_node *)x_malloc(sizeof(t_deque_node));
+	node = (t_deque_node *)malloc(sizeof(t_deque_node));
+	if (node == NULL)
+		return (NULL);
 	node->content = content;
 	node->next = NULL;
 	node->prev = NULL;

--- a/libft/srcs/ft_split.c
+++ b/libft/srcs/ft_split.c
@@ -1,4 +1,5 @@
 #include "libft.h"
+#include <stdlib.h>
 
 static bool	is_delimiter(const char c, const char *charset)
 {
@@ -76,7 +77,9 @@ char	**ft_split(char const *s, const char *charset)
 	if (s == NULL)
 		return (NULL);
 	len = count_words(s, charset);
-	split_strs = (char **)x_malloc(sizeof(char *) * (len + 1));
+	split_strs = (char **)malloc(sizeof(char *) * (len + 1));
+	if (split_strs == NULL)
+		return (NULL);
 	if (!set_split_str(s, charset, split_strs))
 		return (free_2d_array(&split_strs));
 	split_strs[len] = NULL;

--- a/libft/srcs/ft_strdup.c
+++ b/libft/srcs/ft_strdup.c
@@ -1,4 +1,5 @@
 #include "libft.h"
+#include <stdlib.h>
 
 char	*ft_strdup(const char *s)
 {
@@ -6,7 +7,7 @@ char	*ft_strdup(const char *s)
 	char	*dst;
 
 	len_s = ft_strlen(s);
-	dst = (char *)x_malloc(sizeof(char) * (len_s + 1));
+	dst = (char *)malloc(sizeof(char) * (len_s + 1));
 	if (dst == NULL)
 		return (NULL);
 	ft_strlcpy(dst, s, len_s + 1);

--- a/libft/srcs/ft_strjoin.c
+++ b/libft/srcs/ft_strjoin.c
@@ -1,4 +1,5 @@
 #include "libft.h"
+#include <stdlib.h>
 
 char	*ft_strjoin(char const *s1, char const *s2)
 {
@@ -14,7 +15,7 @@ char	*ft_strjoin(char const *s1, char const *s2)
 	len_s1 = ft_strlen(s1);
 	len_s2 = ft_strlen(s2);
 	total = len_s1 + len_s2;
-	res = (char *)x_malloc(sizeof(char) * (total + 1));
+	res = (char *)malloc(sizeof(char) * (total + 1));
 	if (res == NULL)
 		return (NULL);
 	ft_strlcpy(res, s1, len_s1 + 1);

--- a/libft/srcs/ft_strndup.c
+++ b/libft/srcs/ft_strndup.c
@@ -1,11 +1,14 @@
 #include "libft.h"
+#include <stdlib.h>
 
 char	*ft_strndup(const char *s, const size_t maxlen)
 {
 	const size_t	len_s = ft_strnlen(s, maxlen);
 	char			*dst;
 
-	dst = (char *)x_malloc(sizeof(char) * (len_s + 1));
+	dst = (char *)malloc(sizeof(char) * (len_s + 1));
+	if (dst == NULL)
+		return (NULL);
 	ft_strlcpy_void(dst, s, len_s + 1);
 	return (dst);
 }

--- a/libft/srcs/get_next_line.c
+++ b/libft/srcs/get_next_line.c
@@ -27,7 +27,9 @@ static char	*read_buf(char **saved, int fd, bool *finish_read, t_result *result)
 	char	*buf;
 	ssize_t	read_ret;
 
-	buf = (char *)x_malloc(sizeof(char) * ((size_t)BUFFER_SIZE + 1));
+	buf = (char *)malloc(sizeof(char) * ((size_t)BUFFER_SIZE + 1));
+	if (buf == NULL)
+		return (NULL);
 	read_ret = read(fd, buf, BUFFER_SIZE);
 	if (read_ret == READ_ERROR)
 	{

--- a/libft/srcs/get_next_line.c
+++ b/libft/srcs/get_next_line.c
@@ -22,7 +22,7 @@ static void	*ft_free_for_gnl(char **saved, char *ps)
 	return (NULL);
 }
 
-static char	*read_buf(char **saved, int fd, bool *finish_read, t_result *result)
+static char	*read_buf(char **saved, int fd, bool *finish_read, bool *is_error)
 {
 	char	*buf;
 	ssize_t	read_ret;
@@ -33,7 +33,7 @@ static char	*read_buf(char **saved, int fd, bool *finish_read, t_result *result)
 	read_ret = read(fd, buf, BUFFER_SIZE);
 	if (read_ret == READ_ERROR)
 	{
-		*result = FAILURE;
+		*is_error = true;
 		return (ft_free_for_gnl(saved, buf));
 	}
 	buf[read_ret] = CHR_NULL;
@@ -67,19 +67,20 @@ static char	*create_one_line(char **saved)
 	return (left);
 }
 
-char	*get_next_line(int fd, t_result *result)
+char	*get_next_line(int fd, bool *is_error)
 {
 	static char	*saved = NULL;
 	bool		finish_read;
 	char		*buf;
 	char		*tmp;
 
+	*is_error = false;
 	finish_read = false;
 	while (!finish_read)
 	{
 		if (is_new_line(saved))
 			break ;
-		buf = read_buf(&saved, fd, &finish_read, result);
+		buf = read_buf(&saved, fd, &finish_read, is_error);
 		if (!buf)
 			return (ft_free_for_gnl(&saved, NULL));
 		tmp = ft_strjoin(saved, buf);

--- a/srcs/camera/camera.c
+++ b/srcs/camera/camera.c
@@ -1,5 +1,5 @@
 #include "camera.h"
-#include "libft.h"
+#include "helpers.h"
 #include "parse.h"
 #include "result.h"
 

--- a/srcs/cylinder/cylinder.c
+++ b/srcs/cylinder/cylinder.c
@@ -1,4 +1,4 @@
-#include "libft.h"
+#include "helpers.h"
 #include "object.h"
 #include "parse.h"
 #include "result.h"

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -21,11 +21,9 @@ static void	debug_print_camera_and_light(const t_scene *scene)
 	debug_print_vector("scene->camera->pos", scene->camera->pos);
 	debug_print_vector("scene->camera->dir_norm", scene->camera->dir_norm);
 	printf("scene->camera->fov = %d\n", scene->camera->fov);
-
 	printf("** light_ambient\n");
 	printf("scene->light_ambient->bright = %f\n", scene->light_ambient->bright);
 	debug_print_rgb("scene->light_ambient->color", scene->light_ambient->color);
-
 	printf("** light\n");
 	debug_print_vector("scene->light->pos", scene->light->pos);
 	printf("scene->light->bright = %f\n", scene->light->bright);

--- a/srcs/error/error.c
+++ b/srcs/error/error.c
@@ -2,7 +2,6 @@
 #include <stdlib.h> // exit
 #include <unistd.h>
 
-// todo: #12 perror
 void	error_exit(const char *message)
 {
 	ft_putstr_fd(message, STDERR_FILENO);

--- a/srcs/error/error.c
+++ b/srcs/error/error.c
@@ -1,10 +1,17 @@
+#include "error.h"
 #include "libft.h"
 #include <stdlib.h> // exit
 #include <unistd.h>
 
-void	error_exit(const char *message)
+void	putstr_with_endl(const char *message)
 {
 	ft_putstr_fd(message, STDERR_FILENO);
 	ft_putstr_fd("\n", STDERR_FILENO);
+}
+
+void	error_exit(const char *message)
+{
+	putstr_with_endl(ERR_MESSAGE);
+	putstr_with_endl(message);
 	exit(EXIT_FAILURE);
 }

--- a/srcs/helpers/x_ft_split.c
+++ b/srcs/helpers/x_ft_split.c
@@ -1,0 +1,20 @@
+#include "error.h"
+#include "libft.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+char	**x_ft_split(char const *str, const char *charset)
+{
+	char	**split_str;
+
+	if (str == NULL)
+		return (NULL);
+	split_str = ft_split(str, charset);
+	if (split_str == NULL)
+	{
+		putstr_with_endl(ERR_MESSAGE);
+		perror("malloc");
+		exit(EXIT_FAILURE);
+	}
+	return (split_str);
+}

--- a/srcs/helpers/x_get_next_line.c
+++ b/srcs/helpers/x_get_next_line.c
@@ -1,0 +1,20 @@
+#include "error.h"
+#include "get_next_line.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+char	*x_get_next_line(int fd)
+{
+	bool	is_error;
+	char	*line;
+
+	is_error = false;
+	line = get_next_line(fd, &is_error);
+	if (is_error)
+	{
+		putstr_with_endl(ERR_MESSAGE);
+		perror("read");
+		exit(EXIT_FAILURE);
+	}
+	return (line);
+}

--- a/srcs/helpers/x_malloc.c
+++ b/srcs/helpers/x_malloc.c
@@ -1,5 +1,6 @@
-#include <stdlib.h>
+#include "error.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 void	*x_malloc(const size_t size)
 {
@@ -8,6 +9,7 @@ void	*x_malloc(const size_t size)
 	ptr = (void *)malloc(size);
 	if (ptr == NULL)
 	{
+		putstr_with_endl(ERR_MESSAGE);
 		perror("malloc");
 		exit(EXIT_FAILURE);
 	}

--- a/srcs/helpers/x_open.c
+++ b/srcs/helpers/x_open.c
@@ -1,0 +1,19 @@
+#include "error.h"
+#include "helpers.h"
+#include <fcntl.h> // open
+#include <stdio.h>
+#include <stdlib.h>
+
+int	x_open(const char *path, int open_flag)
+{
+	int	ret;
+
+	ret = open(path, open_flag);
+	if (ret == OPEN_ERROR)
+	{
+		putstr_with_endl(ERR_MESSAGE);
+		perror("open");
+		exit(EXIT_FAILURE);
+	}
+	return (ret);
+}

--- a/srcs/light/light.c
+++ b/srcs/light/light.c
@@ -1,4 +1,4 @@
-#include "libft.h"
+#include "helpers.h"
 #include "light.h"
 #include "parse.h"
 

--- a/srcs/parser/check_file_path.c
+++ b/srcs/parser/check_file_path.c
@@ -1,7 +1,7 @@
 #include "helpers.h"
 #include "libft.h"
 #include "parse.h"
-#include <fcntl.h> // open
+#include <fcntl.h> // open_flag
 #include <stdio.h>
 #include <unistd.h>
 
@@ -31,12 +31,7 @@ static bool	is_file_exist(const char *filepath)
 {
 	int	fd;
 
-	fd = open(filepath, O_RDONLY);
-	if (fd == OPEN_ERROR)
-	{
-		perror("open");
-		return (false);
-	}
+	fd = x_open(filepath, O_RDONLY);
 	close(fd);
 	return (true);
 }

--- a/srcs/parser/check_file_path.c
+++ b/srcs/parser/check_file_path.c
@@ -1,3 +1,4 @@
+#include "helpers.h"
 #include "libft.h"
 #include "parse.h"
 #include <fcntl.h> // open

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -1,4 +1,4 @@
-#include "debug.h" // todo: remove
+#include "debug.h"
 #include "ft_deque.h"
 #include "libft.h"
 #include "parse.h"
@@ -46,7 +46,6 @@ t_result	parse(const char *file_name, t_scene *scene)
 		deque_clear_all(&lines, del_lines);
 		return (FAILURE);
 	}
-	debug_deque_print(lines, __func__, (void *)print_2d_array);
 	init_scene(scene);
 	result = parse_lines_to_scene(lines, scene);
 	if (result == FAILURE)

--- a/srcs/parser/read.c
+++ b/srcs/parser/read.c
@@ -9,13 +9,12 @@ static t_deque	*read_lines(const int fd)
 {
 	t_deque			*lines;
 	char			*line;
-	t_result		result;
 	t_deque_node	*node;
 
 	lines = deque_new();
 	while (true)
 	{
-		line = get_next_line(fd, &result); // todo: if result==FAILURE
+		line = x_get_next_line(fd);
 		if (line == NULL)
 			break ;
 		node = deque_node_new((void *)line);

--- a/srcs/parser/read.c
+++ b/srcs/parser/read.c
@@ -18,7 +18,6 @@ static t_deque	*read_lines(const int fd)
 		line = get_next_line(fd, &result); // todo: if result==FAILURE
 		if (line == NULL)
 			break ;
-		// todo: remove last newline?
 		node = deque_node_new((void *)line);
 		deque_add_back(lines, node);
 	}

--- a/srcs/parser/read.c
+++ b/srcs/parser/read.c
@@ -1,5 +1,5 @@
 #include "ft_deque.h"
-#include "get_next_line.h"
+#include "helpers.h"
 #include "libft.h"
 #include "parse.h"
 #include "scene.h"

--- a/srcs/parser/read.c
+++ b/srcs/parser/read.c
@@ -3,7 +3,8 @@
 #include "libft.h"
 #include "parse.h"
 #include "scene.h"
-#include <fcntl.h> // open
+#include <fcntl.h> // open_flag
+#include <unistd.h>
 
 static t_deque	*read_lines(const int fd)
 {
@@ -28,8 +29,9 @@ t_deque	*read_file(const char *file_name)
 	int		fd;
 	t_deque	*lines;
 
-	fd = open(file_name, O_RDONLY); // todo: create x_open with error handle
+	fd = x_open(file_name, O_RDONLY);
 	lines = read_lines(fd);
+	close(fd);
 	return (lines);
 }
 

--- a/srcs/plane/plane.c
+++ b/srcs/plane/plane.c
@@ -1,4 +1,4 @@
-#include "libft.h"
+#include "helpers.h"
 #include "object.h"
 #include "parse.h"
 #include "result.h"

--- a/srcs/sphere/sphere.c
+++ b/srcs/sphere/sphere.c
@@ -1,4 +1,4 @@
-#include "libft.h"
+#include "helpers.h"
 #include "object.h"
 #include "parse.h"
 #include "result.h"


### PR DESCRIPTION
- [x] 不要なコメント削除
- [x] open 時の perror
- [x] `x_` 系を wrap して libft ではなく miniRT 内の `helpers` に入れる (`x_malloc`, `x_open`, `x_get_next_line`, `x_ft_split`)
- [x] error message を PDF 通りに変更 (まず `Error\n` を出力した後に詳細を出力)