### PR TITLE
fix: header

### DIFF
--- a/includes/camera.h
+++ b/includes/camera.h
@@ -1,9 +1,8 @@
 #ifndef CAMERA_H
 # define CAMERA_H
 
+# include "result.h"
 # include "vector.h"
-
-typedef enum e_result	t_result;
 
 typedef struct s_camera
 {

--- a/includes/debug.h
+++ b/includes/debug.h
@@ -1,12 +1,12 @@
 #ifndef DEBUG_H
 # define DEBUG_H
 
-typedef struct s_sphere		t_sphere;
-typedef struct s_plane		t_plane;
 typedef struct s_cylinder	t_cylinder;
-typedef struct s_scene		t_scene;
-typedef struct s_vector		t_vector;
+typedef struct s_plane		t_plane;
 typedef struct s_rgb		t_rgb;
+typedef struct s_scene		t_scene;
+typedef struct s_sphere		t_sphere;
+typedef struct s_vector		t_vector;
 
 /* debug */
 void	debug_print_vector(const char *name, const t_vector vec);

--- a/includes/display.h
+++ b/includes/display.h
@@ -1,8 +1,8 @@
 #ifndef DISPLAY_H
 # define DISPLAY_H
 
-# include "vector.h"
 # include "quaternion.h"
+# include "vector.h"
 
 # define TITLE	"miniRT"
 # define HEIGHT	512
@@ -14,9 +14,9 @@
 
 # define UNREACHABLE	0
 
-typedef struct s_scene	t_scene;
-typedef struct s_rgb	t_rgb;
 typedef struct s_ray	t_ray;
+typedef struct s_rgb	t_rgb;
+typedef struct s_scene	t_scene;
 
 typedef struct s_display
 {

--- a/includes/light.h
+++ b/includes/light.h
@@ -2,9 +2,8 @@
 # define LIGHT_H
 
 # include "color.h"
+# include "result.h"
 # include "vector.h"
-
-typedef enum e_result	t_result;
 
 typedef struct s_light_ambient
 {

--- a/includes/object.h
+++ b/includes/object.h
@@ -8,6 +8,7 @@
 typedef struct s_deque			t_deque;
 typedef struct s_intersection	t_intersection;
 typedef struct s_ray			t_ray;
+typedef struct s_scene			t_scene;
 
 typedef enum s_shape
 {

--- a/includes/object.h
+++ b/includes/object.h
@@ -2,13 +2,12 @@
 # define OBJECT_H
 
 # include "color.h"
+# include "result.h"
 # include "vector.h"
 
-typedef struct s_scene			t_scene;
 typedef struct s_deque			t_deque;
 typedef struct s_intersection	t_intersection;
 typedef struct s_ray			t_ray;
-typedef enum e_result			t_result;
 
 typedef enum s_shape
 {

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -3,6 +3,7 @@
 
 # include <stdbool.h>
 # include <stdint.h>
+# include "result.h"
 
 # define FILE_EXTENSION			".rt"
 # define AT_LEAST_LINES			3
@@ -31,7 +32,6 @@
 
 typedef struct s_scene	t_scene;
 typedef struct s_rgb	t_rgb;
-typedef enum e_result	t_result;
 typedef struct s_deque	t_deque;
 typedef struct s_vector	t_vector;
 

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -30,9 +30,9 @@
 # define VALID_NORMAL_LEN_MIN	(0.99)
 # define VALID_NORMAL_LEN_MAX	(1.01)
 
-typedef struct s_scene	t_scene;
-typedef struct s_rgb	t_rgb;
 typedef struct s_deque	t_deque;
+typedef struct s_rgb	t_rgb;
+typedef struct s_scene	t_scene;
 typedef struct s_vector	t_vector;
 
 typedef enum e_identifier

--- a/includes/quaternion.h
+++ b/includes/quaternion.h
@@ -1,6 +1,9 @@
 #ifndef QUATERNION_H
 # define QUATERNION_H
 
+typedef struct s_screen_info	t_screen_info;
+typedef struct s_vector			t_vector;
+
 typedef struct s_quaternion {
 	double	w;
 	double	x;
@@ -12,4 +15,5 @@ typedef struct s_quaternion {
 t_quaternion	get_rotate_quaternion(t_vector axis, double angle);
 t_vector		rotate_vector_by_quaternion(\
 	t_vector dir_norm, t_vector v, t_screen_info screen);
+
 #endif

--- a/includes/ray.h
+++ b/includes/ray.h
@@ -6,10 +6,10 @@
 # define NO_INTERSECTION	(-1)
 # define NOT_ILLUMINATED	(-1)
 
-typedef struct s_scene			t_scene;
-typedef struct s_light_ambient	t_light_ambient;
 typedef struct s_light			t_light;
+typedef struct s_light_ambient	t_light_ambient;
 typedef struct s_rgb_f			t_rgb_f;
+typedef struct s_scene			t_scene;
 
 typedef struct s_ray
 {

--- a/includes/scene.h
+++ b/includes/scene.h
@@ -1,6 +1,8 @@
 #ifndef SCENE_H
 # define SCENE_H
 
+# include "result.h"
+
 # define TYPE_AMBIENT	"A"
 # define TYPE_CAMERA	"C"
 # define TYPE_LIGHT		"L"
@@ -12,7 +14,6 @@ typedef struct s_light_ambient	t_light_ambient;
 typedef struct s_light			t_light;
 typedef struct s_deque			t_deque;
 typedef struct s_camera			t_camera;
-typedef enum e_result			t_result;
 
 typedef struct s_scene
 {

--- a/includes/scene.h
+++ b/includes/scene.h
@@ -10,10 +10,10 @@
 # define TYPE_SPHERE	"sp"
 # define TYPE_CYLINDER	"cy"
 
-typedef struct s_light_ambient	t_light_ambient;
-typedef struct s_light			t_light;
-typedef struct s_deque			t_deque;
 typedef struct s_camera			t_camera;
+typedef struct s_deque			t_deque;
+typedef struct s_light			t_light;
+typedef struct s_light_ambient	t_light_ambient;
 
 typedef struct s_scene
 {

--- a/srcs/camera/camera.c
+++ b/srcs/camera/camera.c
@@ -1,7 +1,6 @@
 #include "camera.h"
 #include "helpers.h"
 #include "parse.h"
-#include "result.h"
 
 t_camera	*init_camera(const char **line, t_result *result)
 {

--- a/srcs/cylinder/cylinder.c
+++ b/srcs/cylinder/cylinder.c
@@ -1,7 +1,6 @@
 #include "helpers.h"
 #include "object.h"
 #include "parse.h"
-#include "result.h"
 
 t_cylinder	*init_cylinder(const char **line, t_result *result)
 {

--- a/srcs/cylinder/cylinder_color.c
+++ b/srcs/cylinder/cylinder_color.c
@@ -1,7 +1,6 @@
 #include "helpers.h"
 #include "object.h"
 #include "ray.h"
-#include "vector.h"
 #include <math.h>
 
 bool	is_cylinder_self_shadow(\

--- a/srcs/cylinder/cylinder_color.c
+++ b/srcs/cylinder/cylinder_color.c
@@ -3,8 +3,7 @@
 #include "ray.h"
 #include <math.h>
 
-bool	is_cylinder_self_shadow(\
-	t_cylinder *cylinder, const t_ray *ray_shadow)
+bool	is_cylinder_self_shadow(t_cylinder *cylinder, const t_ray *ray_shadow)
 {
 	double		distances[2];
 	double		distance_min;

--- a/srcs/cylinder/cylinder_ray.c
+++ b/srcs/cylinder/cylinder_ray.c
@@ -3,7 +3,7 @@
 #include <math.h>
 
 bool	is_intersect_cylinder(\
-				const t_ray *ray, const t_cylinder *cylinder, double distance)
+	const t_ray *ray, const t_cylinder *cylinder, double distance)
 {
 	const t_vector	pa = vec_add(\
 		ray->position, vec_scalar(ray->direction, distance));

--- a/srcs/display/display.c
+++ b/srcs/display/display.c
@@ -5,7 +5,7 @@
 #include <X11/X.h> // mlx_hook
 
 void	my_mlx_pixel_put(\
-					t_image *image, const int y, const int x, const int color)
+	t_image *image, const int y, const int x, const int color)
 {
 	char	*dst;
 	int		offset;
@@ -31,7 +31,7 @@ static void	set_image(t_mlx *mlxs, t_scene *scene)
 		screen.y++;
 	}
 	mlx_put_image_to_window(\
-			mlxs->display->mlx_p, mlxs->display->win_p, mlxs->image->img, 0, 0);
+		mlxs->display->mlx_p, mlxs->display->win_p, mlxs->image->img, 0, 0);
 }
 
 static int	close_window(const t_mlx *mlxs)

--- a/srcs/display/screen.c
+++ b/srcs/display/screen.c
@@ -31,8 +31,7 @@ t_screen_info	get_screen_info(t_scene *scene)
 	screen.y = 0;
 	screen.axis = set_axis_base();
 	screen.center_screen = get_center_screen(scene->camera);
-	rotation_angle = \
-		vec_angle(set_axis_base(), scene->camera->dir_norm);
+	rotation_angle = vec_angle(set_axis_base(), scene->camera->dir_norm);
 	r_axis = vec_normalize(vec_cross(screen.axis, scene->camera->dir_norm));
 	screen.q_rotate = get_rotate_quaternion(r_axis, rotation_angle);
 	return (screen);

--- a/srcs/light/light.c
+++ b/srcs/light/light.c
@@ -7,8 +7,8 @@ t_light_ambient	*init_light_ambient(const char **line, t_result *result)
 	t_light_ambient	*light_ambient;
 
 	light_ambient = (t_light_ambient *)x_malloc(sizeof(t_light_ambient));
-	light_ambient->bright = convert_to_double_in_range(\
-										line[0], RATIO_MIN, RATIO_MAX, result);
+	light_ambient->bright = \
+		convert_to_double_in_range(line[0], RATIO_MIN, RATIO_MAX, result);
 	light_ambient->color = convert_line_to_rgb(line[1], result);
 	return (light_ambient);
 }
@@ -19,8 +19,8 @@ t_light	*init_light(const char **line, t_result *result)
 
 	light = (t_light *)x_malloc(sizeof(t_light));
 	light->pos = convert_line_to_vector(line[0], result);
-	light->bright = convert_to_double_in_range(\
-										line[1], RATIO_MIN, RATIO_MAX, result);
+	light->bright = \
+		convert_to_double_in_range(line[1], RATIO_MIN, RATIO_MAX, result);
 	light->color = convert_line_to_rgb(line[2], result);
 	return (light);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,7 +1,6 @@
 #include "display.h"
 #include "error.h"
 #include "parse.h"
-#include "result.h"
 #include "scene.h"
 #include <stdlib.h>
 

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -53,7 +53,7 @@ void	*get_nearest_object(const t_ray	*ray, t_deque *list_object)
 
 // only PLANE or SPHERE or CYLINDER
 static t_deque_node	*get_new_object_node(\
-						const char **line, const t_shape type, t_result *result)
+	const char **line, const t_shape type, t_result *result)
 {
 	t_deque_node	*node;
 	void			*object;
@@ -70,7 +70,7 @@ static t_deque_node	*get_new_object_node(\
 }
 
 t_result	add_to_list_object(\
-					t_deque *list_object, const char **line, const t_shape type)
+	t_deque *list_object, const char **line, const t_shape type)
 {
 	t_deque_node	*node;
 	t_result		result;

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -1,7 +1,6 @@
 #include "ft_deque.h"
 #include "helpers.h"
 #include "object.h"
-#include "result.h"
 #include "scene.h"
 #include <math.h>
 #include <stdlib.h> // free

--- a/srcs/object/object.c
+++ b/srcs/object/object.c
@@ -1,7 +1,6 @@
 #include "ft_deque.h"
 #include "helpers.h"
 #include "object.h"
-#include "scene.h"
 #include <math.h>
 #include <stdlib.h> // free
 

--- a/srcs/parser/check_file_path.c
+++ b/srcs/parser/check_file_path.c
@@ -5,13 +5,13 @@
 #include <unistd.h>
 
 static char	*find_head_extention_pointer(\
-								const char *filepath, const size_t len_filepath)
+	const char *filepath, const size_t len_filepath)
 {
 	return (ft_strnstr(filepath, FILE_EXTENSION, len_filepath));
 }
 
 static bool	ends_with_single_extension(\
-						const char *extension_ptr, const size_t len_filepath)
+	const char *extension_ptr, const size_t len_filepath)
 {
 	return (ft_strncmp(extension_ptr, FILE_EXTENSION, len_filepath) == 0);
 }
@@ -39,7 +39,7 @@ bool	is_valid_file_path(const char *filepath)
 {
 	const size_t	len_filepath = ft_strlen(filepath);
 	const char		*extension_ptr = \
-							find_head_extention_pointer(filepath, len_filepath);
+		find_head_extention_pointer(filepath, len_filepath);
 
 	if (extension_ptr == NULL)
 		return (false);

--- a/srcs/parser/check_file_path.c
+++ b/srcs/parser/check_file_path.c
@@ -2,7 +2,6 @@
 #include "libft.h"
 #include "parse.h"
 #include <fcntl.h> // open_flag
-#include <stdio.h>
 #include <unistd.h>
 
 static char	*find_head_extention_pointer(\

--- a/srcs/parser/convert_double.c
+++ b/srcs/parser/convert_double.c
@@ -1,6 +1,5 @@
 #include "libft.h"
 #include "parse.h"
-#include "result.h"
 #include "vector.h"
 
 double	convert_to_double(const char *s, t_result *result)

--- a/srcs/parser/convert_double.c
+++ b/srcs/parser/convert_double.c
@@ -14,7 +14,7 @@ double	convert_to_double(const char *s, t_result *result)
 }
 
 double	convert_to_double_in_range(\
-			const char *s, const double min, const double max, t_result *result)
+	const char *s, const double min, const double max, t_result *result)
 {
 	double	num;
 
@@ -41,7 +41,7 @@ t_vector	convert_line_to_vector(const char *line, t_result *result)
 }
 
 t_vector	convert_line_to_vector_in_range(\
-		const char *line, const double min, const double max, t_result *result)
+	const char *line, const double min, const double max, t_result *result)
 {
 	t_vector	vec;
 	char		**strs;

--- a/srcs/parser/convert_lines_to_scene.c
+++ b/srcs/parser/convert_lines_to_scene.c
@@ -3,7 +3,6 @@
 #include "light.h"
 #include "object.h"
 #include "parse.h"
-#include "result.h"
 #include "scene.h"
 
 t_vector	init_normal_vector(\

--- a/srcs/parser/convert_lines_to_scene.c
+++ b/srcs/parser/convert_lines_to_scene.c
@@ -6,7 +6,7 @@
 #include "scene.h"
 
 t_vector	init_normal_vector(\
-		const char *line, const double min, const double max, t_result *result)
+	const char *line, const double min, const double max, t_result *result)
 {
 	t_vector	normal;
 	double		length;

--- a/srcs/parser/convert_uint8_t.c
+++ b/srcs/parser/convert_uint8_t.c
@@ -1,7 +1,6 @@
 #include "color.h"
 #include "libft.h"
 #include "parse.h"
-#include "result.h"
 
 // min: 0 ~ 255, max: 0 ~ 255
 uint8_t	convert_to_uint8_in_range(\

--- a/srcs/parser/convert_uint8_t.c
+++ b/srcs/parser/convert_uint8_t.c
@@ -4,7 +4,7 @@
 
 // min: 0 ~ 255, max: 0 ~ 255
 uint8_t	convert_to_uint8_in_range(\
-				const char *s, const int min, const int max, t_result *result)
+	const char *s, const int min, const int max, t_result *result)
 {
 	int		num;
 	bool	ret;

--- a/srcs/parser/is_correct_value_count.c
+++ b/srcs/parser/is_correct_value_count.c
@@ -16,7 +16,7 @@ static size_t	count_value(const char *s)
 }
 
 static bool	is_correct_value_count(\
-		const char **line, const size_t *value_counts, const size_t elem_count)
+	const char **line, const size_t *value_counts, const size_t elem_count)
 {
 	size_t	i;
 	size_t	value_count;
@@ -39,26 +39,26 @@ static bool	is_correct_value_count(\
 // sp [1,2,3]   [1]   [1,2,3]
 // cy [1,2,3] [1,2,3]   [1]   [1] [1,2,3]
 static bool	is_correct_value_counts_in_each_info(\
-									const char **line, const t_identifier id)
+	const char **line, const t_identifier id)
 {
 	if (id == ID_AMBIENT)
 		return (is_correct_value_count(\
-					line, (size_t []){1, 3}, ELEM_COUNT_AMBIENT - 1));
+			line, (size_t []){1, 3}, ELEM_COUNT_AMBIENT - 1));
 	if (id == ID_CAMERA)
 		return (is_correct_value_count(\
-					line, (size_t []){3, 3, 1}, ELEM_COUNT_CAMERA - 1));
+			line, (size_t []){3, 3, 1}, ELEM_COUNT_CAMERA - 1));
 	if (id == ID_LIGHT)
 		return (is_correct_value_count(\
-					line, (size_t []){3, 1, 3}, ELEM_COUNT_LIGHT - 1));
+			line, (size_t []){3, 1, 3}, ELEM_COUNT_LIGHT - 1));
 	if (id == ID_PLANE)
 		return (is_correct_value_count(\
-					line, (size_t []){3, 3, 3}, ELEM_COUNT_PLANE - 1));
+			line, (size_t []){3, 3, 3}, ELEM_COUNT_PLANE - 1));
 	if (id == ID_SPHERE)
 		return (is_correct_value_count(\
-					line, (size_t []){3, 1, 3}, ELEM_COUNT_SPHERE - 1));
+			line, (size_t []){3, 1, 3}, ELEM_COUNT_SPHERE - 1));
 	if (id == ID_CYLINDER)
 		return (is_correct_value_count(\
-					line, (size_t []){3, 3, 1, 1, 3}, ELEM_COUNT_CYLINDER - 1));
+			line, (size_t []){3, 3, 1, 1, 3}, ELEM_COUNT_CYLINDER - 1));
 	return (false);
 }
 

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -2,7 +2,6 @@
 #include "ft_deque.h"
 #include "libft.h"
 #include "parse.h"
-#include "result.h"
 #include "scene.h"
 
 /*

--- a/srcs/plane/plane.c
+++ b/srcs/plane/plane.c
@@ -1,7 +1,6 @@
 #include "helpers.h"
 #include "object.h"
 #include "parse.h"
-#include "result.h"
 
 t_plane	*init_plane(const char **line, t_result *result)
 {

--- a/srcs/sphere/sphere.c
+++ b/srcs/sphere/sphere.c
@@ -1,7 +1,6 @@
 #include "helpers.h"
 #include "object.h"
 #include "parse.h"
-#include "result.h"
 
 t_sphere	*init_sphere(const char **line, t_result *result)
 {


### PR DESCRIPTION
- linux で compile flag に `-pedantic` をつけると enum の前方宣言が怒られるので、一応修正しました
```shell
./includes/scene.h:17:14: error: ISO C forbids forward references to ‘enum’ types [-Werror=pedantic]
   17 | typedef enum e_result                   t_result;
      |              ^~~~~~~~
cc1: all warnings being treated as errors
```
- 残党の header を削除しました
- fmt : indent 揃えました